### PR TITLE
feat: complete node management service and mappers

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcNodeController.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcNodeController.java
@@ -1,0 +1,94 @@
+package com.zjlab.dataservice.modules.tc.controller;
+
+import com.github.xiaoymin.knife4j.annotations.ApiOperationSupport;
+import com.zjlab.dataservice.common.api.page.PageResult;
+import com.zjlab.dataservice.common.api.vo.Result;
+import com.zjlab.dataservice.modules.tc.model.dto.*;
+import com.zjlab.dataservice.modules.tc.service.TcNodeService;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 节点管理接口
+ */
+@RestController
+@RequestMapping("/tc/node")
+public class TcNodeController {
+
+    @Autowired
+    private TcNodeService tcNodeService;
+
+    /**
+     * 获取节点统计数据
+     */
+    @GetMapping("/stats")
+    @ApiOperationSupport(order = 1)
+    @ApiOperation(value = "获取节点统计数据")
+    public Result<NodeStatsVo> stats() {
+        return Result.ok(tcNodeService.getStats());
+    }
+
+    /**
+     * 查询节点列表
+     */
+    @GetMapping("/list")
+    @ApiOperationSupport(order = 2)
+    @ApiOperation(value = "查询节点列表")
+    public Result<PageResult<NodeListDto>> list(NodeQueryDto queryDto) {
+        return Result.ok(tcNodeService.listNodes(queryDto));
+    }
+
+    /**
+     * 新建节点
+     */
+    @PostMapping("/create")
+    @ApiOperationSupport(order = 3)
+    @ApiOperation(value = "新建节点")
+    public Result<Long> create(@RequestBody NodeCreateOrUpdateDto dto) {
+        return Result.ok(tcNodeService.createNode(dto));
+    }
+
+    /**
+     * 编辑节点
+     */
+    @PutMapping("/update/{id}")
+    @ApiOperationSupport(order = 4)
+    @ApiOperation(value = "编辑节点")
+    public Result<Void> update(@PathVariable Long id, @RequestBody NodeCreateOrUpdateDto dto) {
+        tcNodeService.updateNode(id, dto);
+        return Result.ok();
+    }
+
+    /**
+     * 更新节点状态
+     */
+    @PatchMapping("/status/{id}")
+    @ApiOperationSupport(order = 5)
+    @ApiOperation(value = "更新节点状态")
+    public Result<Void> updateStatus(@PathVariable Long id, @RequestBody NodeStatusDto dto) {
+        tcNodeService.updateStatus(id, dto.getStatus());
+        return Result.ok();
+    }
+
+    /**
+     * 删除节点
+     */
+    @DeleteMapping("/delete/{id}")
+    @ApiOperationSupport(order = 6)
+    @ApiOperation(value = "删除节点")
+    public Result<Void> delete(@PathVariable Long id) {
+        tcNodeService.deleteNode(id);
+        return Result.ok();
+    }
+
+    /**
+     * 获取节点详情
+     */
+    @GetMapping("/detail/{id}")
+    @ApiOperationSupport(order = 7)
+    @ApiOperation(value = "获取节点详情")
+    public Result<NodeDetailDto> detail(@PathVariable Long id) {
+        return Result.ok(tcNodeService.getDetail(id));
+    }
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/NodeActionConfigMapper.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/NodeActionConfigMapper.java
@@ -1,0 +1,16 @@
+package com.zjlab.dataservice.modules.tc.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.zjlab.dataservice.modules.tc.model.entity.NodeActionConfig;
+import org.apache.ibatis.annotations.Param;
+import java.util.List;
+
+/**
+ * 操作控制项配置 Mapper
+ */
+public interface NodeActionConfigMapper extends BaseMapper<NodeActionConfig> {
+    /**
+     * 批量查询控制项配置
+     */
+    List<NodeActionConfig> selectByIds(@Param("ids") List<Long> ids);
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/NodeActionRelMapper.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/NodeActionRelMapper.java
@@ -1,0 +1,21 @@
+package com.zjlab.dataservice.modules.tc.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.zjlab.dataservice.modules.tc.model.entity.NodeActionRel;
+import org.apache.ibatis.annotations.Param;
+import java.util.List;
+
+/**
+ * 节点与操作控制项关联 Mapper
+ */
+public interface NodeActionRelMapper extends BaseMapper<NodeActionRel> {
+    /**
+     * 根据节点ID查询关联的控制项
+     */
+    List<NodeActionRel> selectByNodeId(@Param("nodeId") Long nodeId);
+
+    /**
+     * 根据节点ID删除关联记录
+     */
+    int deleteByNodeId(@Param("nodeId") Long nodeId);
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/NodeInfoMapper.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/NodeInfoMapper.java
@@ -1,0 +1,15 @@
+package com.zjlab.dataservice.modules.tc.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.zjlab.dataservice.modules.tc.model.entity.NodeInfo;
+import org.apache.ibatis.annotations.Param;
+
+/**
+ * 节点信息 Mapper
+ */
+public interface NodeInfoMapper extends BaseMapper<NodeInfo> {
+    /**
+     * 根据名称查询节点
+     */
+    NodeInfo selectByName(@Param("name") String name);
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/NodeRoleRelMapper.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/NodeRoleRelMapper.java
@@ -1,0 +1,20 @@
+package com.zjlab.dataservice.modules.tc.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.zjlab.dataservice.modules.tc.model.entity.NodeRoleRel;
+import org.apache.ibatis.annotations.Param;
+
+/**
+ * 节点角色关联 Mapper
+ */
+public interface NodeRoleRelMapper extends BaseMapper<NodeRoleRel> {
+    /**
+     * 根据节点ID查询角色关联
+     */
+    NodeRoleRel selectByNodeId(@Param("nodeId") Long nodeId);
+
+    /**
+     * 根据节点ID删除角色关联
+     */
+    int deleteByNodeId(@Param("nodeId") Long nodeId);
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/NodeActionConfigMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/NodeActionConfigMapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.zjlab.dataservice.modules.tc.mapper.NodeActionConfigMapper">
+    <resultMap id="BaseResultMap" type="com.zjlab.dataservice.modules.tc.model.entity.NodeActionConfig">
+        <id column="id" property="id" />
+        <result column="type" property="type" />
+        <result column="name" property="name" />
+        <result column="config" property="config" />
+        <result column="del_flag" property="delFlag" />
+        <result column="create_by" property="createBy" />
+        <result column="create_time" property="createTime" />
+        <result column="update_by" property="updateBy" />
+        <result column="update_time" property="updateTime" />
+    </resultMap>
+
+    <sql id="Base_Column_List">
+        id, type, name, config, del_flag, create_by, create_time, update_by, update_time
+    </sql>
+
+    <select id="selectByIds" resultMap="BaseResultMap" parameterType="list">
+        SELECT <include refid="Base_Column_List"/>
+        FROM node_action_config
+        WHERE del_flag = 0 AND id IN
+        <foreach collection="ids" item="id" open="(" separator="," close=")">
+            #{id}
+        </foreach>
+    </select>
+</mapper>

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/NodeActionRelMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/NodeActionRelMapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.zjlab.dataservice.modules.tc.mapper.NodeActionRelMapper">
+    <resultMap id="BaseResultMap" type="com.zjlab.dataservice.modules.tc.model.entity.NodeActionRel">
+        <id column="id" property="id" />
+        <result column="node_id" property="nodeId" />
+        <result column="action_id" property="actionId" />
+        <result column="del_flag" property="delFlag" />
+        <result column="create_by" property="createBy" />
+        <result column="create_time" property="createTime" />
+        <result column="update_by" property="updateBy" />
+        <result column="update_time" property="updateTime" />
+    </resultMap>
+
+    <sql id="Base_Column_List">
+        id, node_id, action_id, del_flag, create_by, create_time, update_by, update_time
+    </sql>
+
+    <select id="selectByNodeId" resultMap="BaseResultMap" parameterType="long">
+        SELECT <include refid="Base_Column_List"/>
+        FROM node_action_rel
+        WHERE del_flag = 0 AND node_id = #{nodeId}
+    </select>
+
+    <update id="deleteByNodeId" parameterType="long">
+        UPDATE node_action_rel SET del_flag = 1 WHERE node_id = #{nodeId}
+    </update>
+</mapper>

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/NodeInfoMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/NodeInfoMapper.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.zjlab.dataservice.modules.tc.mapper.NodeInfoMapper">
+    <!-- 基础字段映射 -->
+    <resultMap id="BaseResultMap" type="com.zjlab.dataservice.modules.tc.model.entity.NodeInfo">
+        <id column="id" property="id" />
+        <result column="name" property="name" />
+        <result column="description" property="description" />
+        <result column="expected_duration" property="expectedDuration" />
+        <result column="timeout_remind" property="timeoutRemind" />
+        <result column="status" property="status" />
+        <result column="del_flag" property="delFlag" />
+        <result column="create_by" property="createBy" />
+        <result column="create_time" property="createTime" />
+        <result column="update_by" property="updateBy" />
+        <result column="update_time" property="updateTime" />
+    </resultMap>
+
+    <!-- 通用查询列 -->
+    <sql id="Base_Column_List">
+        id, name, description, expected_duration, timeout_remind, status,
+        del_flag, create_by, create_time, update_by, update_time
+    </sql>
+
+    <select id="selectByName" resultMap="BaseResultMap" parameterType="string">
+        SELECT <include refid="Base_Column_List"/>
+        FROM node_info
+        WHERE del_flag = 0 AND name = #{name}
+        LIMIT 1
+    </select>
+</mapper>

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/NodeRoleRelMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/NodeRoleRelMapper.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.zjlab.dataservice.modules.tc.mapper.NodeRoleRelMapper">
+    <resultMap id="BaseResultMap" type="com.zjlab.dataservice.modules.tc.model.entity.NodeRoleRel">
+        <id column="id" property="id" />
+        <result column="node_id" property="nodeId" />
+        <result column="role_id" property="roleId" />
+        <result column="del_flag" property="delFlag" />
+        <result column="create_by" property="createBy" />
+        <result column="create_time" property="createTime" />
+        <result column="update_by" property="updateBy" />
+        <result column="update_time" property="updateTime" />
+    </resultMap>
+
+    <sql id="Base_Column_List">
+        id, node_id, role_id, del_flag, create_by, create_time, update_by, update_time
+    </sql>
+
+    <select id="selectByNodeId" resultMap="BaseResultMap" parameterType="long">
+        SELECT <include refid="Base_Column_List"/>
+        FROM node_role_rel
+        WHERE del_flag = 0 AND node_id = #{nodeId}
+        LIMIT 1
+    </select>
+
+    <update id="deleteByNodeId" parameterType="long">
+        UPDATE node_role_rel SET del_flag = 1 WHERE node_id = #{nodeId}
+    </update>
+</mapper>

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeActionDto.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeActionDto.java
@@ -1,0 +1,18 @@
+package com.zjlab.dataservice.modules.tc.model.dto;
+
+import lombok.Data;
+
+/**
+ * 操作控制项
+ */
+@Data
+public class NodeActionDto {
+    /** 控制项ID */
+    private Long id;
+    /** 操作类型（0=上传，1=选择圈次计划，2=决策，3=文本填写） */
+    private Integer type;
+    /** 控制项名称 */
+    private String name;
+    /** 控制项配置 JSON 字符串 */
+    private String config;
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeCreateOrUpdateDto.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeCreateOrUpdateDto.java
@@ -1,0 +1,26 @@
+package com.zjlab.dataservice.modules.tc.model.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 新建或编辑节点请求
+ */
+@Data
+public class NodeCreateOrUpdateDto {
+    /** 节点名称 */
+    private String name;
+    /** 节点描述 */
+    private String description;
+    /** 预计处理时长（分钟） */
+    private Integer expectedDuration;
+    /** 超时提醒频率（分钟） */
+    private Integer timeoutRemind;
+    /** 节点状态（1=活跃，0=禁用） */
+    private Integer status;
+    /** 节点角色ID */
+    private Long roleId;
+    /** 绑定的操作控制项 */
+    private List<NodeActionDto> actions;
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeDetailDto.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeDetailDto.java
@@ -1,0 +1,20 @@
+package com.zjlab.dataservice.modules.tc.model.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 节点详情
+ */
+@Data
+public class NodeDetailDto {
+    private Long id;
+    private String name;
+    private String description;
+    private Integer expectedDuration;
+    private Integer timeoutRemind;
+    private Integer status;
+    private Long roleId;
+    private List<NodeActionDto> actions;
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeListDto.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeListDto.java
@@ -1,0 +1,25 @@
+package com.zjlab.dataservice.modules.tc.model.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 节点列表返回
+ */
+@Data
+public class NodeListDto {
+    private Long id;
+    private String name;
+    private String description;
+    private Integer expectedDuration;
+    private Integer timeoutRemind;
+    private Integer status;
+    private Long roleId;
+    private String roleName;
+    private List<String> actionTypes;
+    private Long creatorId;
+    private String creatorName;
+    private LocalDateTime createTime;
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeQueryDto.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeQueryDto.java
@@ -1,0 +1,16 @@
+package com.zjlab.dataservice.modules.tc.model.dto;
+
+import lombok.Data;
+
+/**
+ * 节点列表查询参数
+ */
+@Data
+public class NodeQueryDto {
+    private Integer status;
+    private String name;
+    private String roleName;
+    private String creatorName;
+    private Integer page = 1;
+    private Integer pageSize = 20;
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeStatsVo.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeStatsVo.java
@@ -1,0 +1,17 @@
+package com.zjlab.dataservice.modules.tc.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 节点统计数据
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class NodeStatsVo {
+    private Integer activeCount;
+    private Integer disabledCount;
+    private Integer totalCount;
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeStatusDto.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeStatusDto.java
@@ -1,0 +1,11 @@
+package com.zjlab.dataservice.modules.tc.model.dto;
+
+import lombok.Data;
+
+/**
+ * 更新节点状态
+ */
+@Data
+public class NodeStatusDto {
+    private Integer status;
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/entity/NodeActionConfig.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/entity/NodeActionConfig.java
@@ -1,0 +1,19 @@
+package com.zjlab.dataservice.modules.tc.model.entity;
+
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+/**
+ * 操作控制项配置表
+ */
+@TableName("node_action_config")
+@Data
+public class NodeActionConfig extends TcBaseEntity {
+    /** 操作类型（0=上传，1=选择圈次计划，2=决策，3=文本填写） */
+    private Integer type;
+    /** 操作项名称 */
+    private String name;
+    /** 配置信息 JSON 字符串 */
+    private String config;
+}
+

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/entity/NodeActionRel.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/entity/NodeActionRel.java
@@ -1,0 +1,15 @@
+package com.zjlab.dataservice.modules.tc.model.entity;
+
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+/**
+ * 节点与操作控制项关联表
+ */
+@TableName("node_action_rel")
+@Data
+public class NodeActionRel extends TcBaseEntity {
+    private Long nodeId;
+    private Long actionId;
+}
+

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/entity/NodeInfo.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/entity/NodeInfo.java
@@ -1,0 +1,19 @@
+package com.zjlab.dataservice.modules.tc.model.entity;
+
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+/**
+ * 节点信息表
+ */
+@TableName("node_info")
+@Data
+public class NodeInfo extends TcBaseEntity {
+    private String name;
+    private String description;
+    private Integer expectedDuration;
+    private Integer timeoutRemind;
+    /** 节点状态（1=活跃，0=禁用） */
+    private Integer status;
+}
+

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/entity/NodeRoleRel.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/entity/NodeRoleRel.java
@@ -1,0 +1,15 @@
+package com.zjlab.dataservice.modules.tc.model.entity;
+
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+/**
+ * 节点与角色关联表
+ */
+@TableName("node_role_rel")
+@Data
+public class NodeRoleRel extends TcBaseEntity {
+    private Long nodeId;
+    private Long roleId;
+}
+

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/entity/TcBaseEntity.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/entity/TcBaseEntity.java
@@ -1,0 +1,29 @@
+package com.zjlab.dataservice.modules.tc.model.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableLogic;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 基础实体，包含公共字段
+ */
+@Data
+public class TcBaseEntity {
+    @TableId(value = "id", type = IdType.AUTO)
+    private Long id;
+
+    @TableLogic
+    private Integer delFlag;
+
+    private Long createBy;
+
+    private LocalDateTime createTime;
+
+    private Long updateBy;
+
+    private LocalDateTime updateTime;
+}
+

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/TcNodeService.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/TcNodeService.java
@@ -1,0 +1,20 @@
+package com.zjlab.dataservice.modules.tc.service;
+
+import com.zjlab.dataservice.common.api.page.PageResult;
+import com.zjlab.dataservice.modules.tc.model.dto.*;
+
+public interface TcNodeService {
+    NodeStatsVo getStats();
+
+    PageResult<NodeListDto> listNodes(NodeQueryDto queryDto);
+
+    Long createNode(NodeCreateOrUpdateDto dto);
+
+    void updateNode(Long id, NodeCreateOrUpdateDto dto);
+
+    void updateStatus(Long id, Integer status);
+
+    void deleteNode(Long id);
+
+    NodeDetailDto getDetail(Long id);
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcNodeServiceImpl.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcNodeServiceImpl.java
@@ -1,0 +1,236 @@
+package com.zjlab.dataservice.modules.tc.service.impl;
+
+import cn.hutool.core.bean.BeanUtil;
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.zjlab.dataservice.common.api.page.PageResult;
+import com.zjlab.dataservice.modules.system.entity.SysRole;
+import com.zjlab.dataservice.modules.system.entity.SysUser;
+import com.zjlab.dataservice.modules.system.mapper.SysRoleMapper;
+import com.zjlab.dataservice.modules.system.mapper.SysUserMapper;
+import com.zjlab.dataservice.modules.tc.mapper.NodeActionConfigMapper;
+import com.zjlab.dataservice.modules.tc.mapper.NodeActionRelMapper;
+import com.zjlab.dataservice.modules.tc.mapper.NodeInfoMapper;
+import com.zjlab.dataservice.modules.tc.mapper.NodeRoleRelMapper;
+import com.zjlab.dataservice.modules.tc.model.dto.*;
+import com.zjlab.dataservice.modules.tc.model.entity.*;
+import com.zjlab.dataservice.modules.tc.service.TcNodeService;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * 节点管理服务实现
+ */
+@Service
+public class TcNodeServiceImpl implements TcNodeService {
+
+    @Autowired
+    private NodeInfoMapper nodeInfoMapper;
+    @Autowired
+    private NodeRoleRelMapper nodeRoleRelMapper;
+    @Autowired
+    private NodeActionConfigMapper nodeActionConfigMapper;
+    @Autowired
+    private NodeActionRelMapper nodeActionRelMapper;
+    @Autowired
+    private SysUserMapper sysUserMapper;
+    @Autowired
+    private SysRoleMapper sysRoleMapper;
+
+    @Override
+    public NodeStatsVo getStats() {
+        long active = nodeInfoMapper.selectCount(Wrappers.<NodeInfo>lambdaQuery()
+                .eq(NodeInfo::getDelFlag, 0).eq(NodeInfo::getStatus, 1));
+        long disabled = nodeInfoMapper.selectCount(Wrappers.<NodeInfo>lambdaQuery()
+                .eq(NodeInfo::getDelFlag, 0).eq(NodeInfo::getStatus, 0));
+        long total = nodeInfoMapper.selectCount(Wrappers.<NodeInfo>lambdaQuery()
+                .eq(NodeInfo::getDelFlag, 0));
+        return new NodeStatsVo((int) active, (int) disabled, (int) total);
+    }
+
+    @Override
+    public PageResult<NodeListDto> listNodes(NodeQueryDto queryDto) {
+        Page<NodeInfo> page = new Page<>(queryDto.getPage(), queryDto.getPageSize());
+        LambdaQueryWrapper<NodeInfo> wrapper = Wrappers.<NodeInfo>lambdaQuery()
+                .eq(NodeInfo::getDelFlag, 0);
+        if (queryDto.getStatus() != null) {
+            wrapper.eq(NodeInfo::getStatus, queryDto.getStatus());
+        }
+        if (StringUtils.isNotBlank(queryDto.getName())) {
+            wrapper.like(NodeInfo::getName, queryDto.getName());
+        }
+        if (StringUtils.isNotBlank(queryDto.getCreatorName())) {
+            List<SysUser> users = sysUserMapper.selectList(Wrappers.<SysUser>query()
+                    .like("username", queryDto.getCreatorName()));
+            if (users.isEmpty()) {
+                return new PageResult<>(queryDto.getPage(), queryDto.getPageSize(), 0, Collections.emptyList());
+            }
+            List<Long> userIds = users.stream().map(u -> Long.valueOf(u.getId())).collect(Collectors.toList());
+            wrapper.in(NodeInfo::getCreateBy, userIds);
+        }
+        if (StringUtils.isNotBlank(queryDto.getRoleName())) {
+            List<SysRole> roles = sysRoleMapper.selectList(Wrappers.<SysRole>query()
+                    .like("role_name", queryDto.getRoleName()));
+            if (roles.isEmpty()) {
+                return new PageResult<>(queryDto.getPage(), queryDto.getPageSize(), 0, Collections.emptyList());
+            }
+            List<Long> roleIds = roles.stream().map(r -> Long.valueOf(r.getId())).collect(Collectors.toList());
+            List<Long> nodeIds = nodeRoleRelMapper.selectList(Wrappers.<NodeRoleRel>lambdaQuery()
+                            .eq(NodeRoleRel::getDelFlag, 0)
+                            .in(NodeRoleRel::getRoleId, roleIds))
+                    .stream().map(NodeRoleRel::getNodeId).collect(Collectors.toList());
+            if (nodeIds.isEmpty()) {
+                return new PageResult<>(queryDto.getPage(), queryDto.getPageSize(), 0, Collections.emptyList());
+            }
+            wrapper.in(NodeInfo::getId, nodeIds);
+        }
+
+        IPage<NodeInfo> nodePage = nodeInfoMapper.selectPage(page, wrapper);
+        List<NodeListDto> dtoList = nodePage.getRecords().stream().map(node -> {
+            NodeListDto dto = new NodeListDto();
+            BeanUtil.copyProperties(node, dto);
+            // role
+            NodeRoleRel rel = nodeRoleRelMapper.selectByNodeId(node.getId());
+            if (rel != null) {
+                dto.setRoleId(rel.getRoleId());
+                SysRole role = sysRoleMapper.selectById(String.valueOf(rel.getRoleId()));
+                if (role != null) {
+                    dto.setRoleName(role.getRoleName());
+                }
+            }
+            // actions
+            List<NodeActionRel> rels = nodeActionRelMapper.selectByNodeId(node.getId());
+            if (rels != null && !rels.isEmpty()) {
+                List<Long> actionIds = rels.stream().map(NodeActionRel::getActionId).collect(Collectors.toList());
+                List<NodeActionConfig> cfgs = nodeActionConfigMapper.selectByIds(actionIds);
+                List<String> names = cfgs.stream().map(NodeActionConfig::getName).collect(Collectors.toList());
+                dto.setActionTypes(names);
+            }
+            // creator
+            dto.setCreatorId(node.getCreateBy());
+            SysUser user = sysUserMapper.selectById(String.valueOf(node.getCreateBy()));
+            if (user != null) {
+                dto.setCreatorName(user.getUsername());
+            }
+            dto.setCreateTime(node.getCreateTime());
+            return dto;
+        }).collect(Collectors.toList());
+        return new PageResult<>(nodePage.getCurrent(), nodePage.getSize(), nodePage.getTotal(), dtoList);
+    }
+
+    @Override
+    public Long createNode(NodeCreateOrUpdateDto dto) {
+        NodeInfo node = new NodeInfo();
+        BeanUtil.copyProperties(dto, node);
+        node.setDelFlag(0);
+        nodeInfoMapper.insert(node);
+        NodeRoleRel rel = new NodeRoleRel();
+        rel.setNodeId(node.getId());
+        rel.setRoleId(dto.getRoleId());
+        rel.setDelFlag(0);
+        nodeRoleRelMapper.insert(rel);
+        if (dto.getActions() != null) {
+            for (NodeActionDto actionDto : dto.getActions()) {
+                NodeActionConfig cfg = new NodeActionConfig();
+                cfg.setType(actionDto.getType());
+                cfg.setName(actionDto.getName());
+                cfg.setConfig(actionDto.getConfig());
+                cfg.setDelFlag(0);
+                nodeActionConfigMapper.insert(cfg);
+                NodeActionRel ar = new NodeActionRel();
+                ar.setNodeId(node.getId());
+                ar.setActionId(cfg.getId());
+                ar.setDelFlag(0);
+                nodeActionRelMapper.insert(ar);
+            }
+        }
+        return node.getId();
+    }
+
+    @Override
+    public void updateNode(Long id, NodeCreateOrUpdateDto dto) {
+        NodeInfo node = new NodeInfo();
+        BeanUtil.copyProperties(dto, node);
+        node.setId(id);
+        nodeInfoMapper.updateById(node);
+        nodeRoleRelMapper.deleteByNodeId(id);
+        NodeRoleRel rel = new NodeRoleRel();
+        rel.setNodeId(id);
+        rel.setRoleId(dto.getRoleId());
+        rel.setDelFlag(0);
+        nodeRoleRelMapper.insert(rel);
+        List<NodeActionRel> oldRels = nodeActionRelMapper.selectByNodeId(id);
+        for (NodeActionRel ar : oldRels) {
+            nodeActionConfigMapper.deleteById(ar.getActionId());
+        }
+        nodeActionRelMapper.deleteByNodeId(id);
+        if (dto.getActions() != null) {
+            for (NodeActionDto actionDto : dto.getActions()) {
+                NodeActionConfig cfg = new NodeActionConfig();
+                cfg.setType(actionDto.getType());
+                cfg.setName(actionDto.getName());
+                cfg.setConfig(actionDto.getConfig());
+                cfg.setDelFlag(0);
+                nodeActionConfigMapper.insert(cfg);
+                NodeActionRel ar = new NodeActionRel();
+                ar.setNodeId(id);
+                ar.setActionId(cfg.getId());
+                ar.setDelFlag(0);
+                nodeActionRelMapper.insert(ar);
+            }
+        }
+    }
+
+    @Override
+    public void updateStatus(Long id, Integer status) {
+        NodeInfo node = new NodeInfo();
+        node.setId(id);
+        node.setStatus(status);
+        nodeInfoMapper.updateById(node);
+    }
+
+    @Override
+    public void deleteNode(Long id) {
+        NodeInfo node = new NodeInfo();
+        node.setId(id);
+        node.setDelFlag(1);
+        nodeInfoMapper.updateById(node);
+    }
+
+    @Override
+    public NodeDetailDto getDetail(Long id) {
+        NodeInfo node = nodeInfoMapper.selectById(id);
+        if (node == null || node.getDelFlag() == 1) {
+            return null;
+        }
+        NodeDetailDto dto = new NodeDetailDto();
+        BeanUtil.copyProperties(node, dto);
+        NodeRoleRel rel = nodeRoleRelMapper.selectByNodeId(id);
+        if (rel != null) {
+            dto.setRoleId(rel.getRoleId());
+        }
+        List<NodeActionRel> rels = nodeActionRelMapper.selectByNodeId(id);
+        if (rels != null && !rels.isEmpty()) {
+            List<Long> actionIds = rels.stream().map(NodeActionRel::getActionId).collect(Collectors.toList());
+            List<NodeActionConfig> cfgs = nodeActionConfigMapper.selectByIds(actionIds);
+            List<NodeActionDto> actions = cfgs.stream().map(cfg -> {
+                NodeActionDto a = new NodeActionDto();
+                a.setId(cfg.getId());
+                a.setType(cfg.getType());
+                a.setName(cfg.getName());
+                a.setConfig(cfg.getConfig());
+                return a;
+            }).collect(Collectors.toList());
+            dto.setActions(actions);
+        }
+        return dto;
+    }
+}


### PR DESCRIPTION
## Summary
- adapt node entities to `node_*` tables and expose simple mapper interfaces
- rework node DTOs for single-role binding and action IDs
- implement full TcNodeServiceImpl with stats, filtered listing, CRUD, and detail retrieval
- flesh out node mappers with SQL mappings and helper methods

## Testing
- `mvn -q -pl system/biz -am test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689477e5ee908330a5b63d703abd9d3f