### PR TITLE
feat: enrich node info responses

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeInfoDto.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeInfoDto.java
@@ -36,4 +36,11 @@ public class NodeInfoDto {
     private String creatorName;
     /** 创建时间 */
     private LocalDateTime createTime;
+
+    /** 更新人ID */
+    private Long updaterId;
+    /** 更新人名称 */
+    private String updaterName;
+    /** 更新时间 */
+    private LocalDateTime updateTime;
 }


### PR DESCRIPTION
## Summary
- include action type/name and role names when listing nodes
- capture creator and updater from login context and expose in DTO
- avoid unnecessary role recreation on node updates

## Testing
- `mvn -q -pl system/biz -am test` *(fails: Non-resolvable parent POM, maven.aliyun.com: Name or service not known)*

------
https://chatgpt.com/codex/tasks/task_e_689994ac033c8330bc7d3ace5e97ba6c