### PR TITLE
refactor node handling for roles and metadata

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeActionDto.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeActionDto.java
@@ -7,8 +7,6 @@ import lombok.Data;
  */
 @Data
 public class NodeActionDto {
-    /** 控制项ID */
-    private Long id;
     /** 操作类型（0=上传，1=选择圈次计划，2=决策，3=文本填写） */
     private Integer type;
     /** 控制项名称 */

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeInfoDto.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeInfoDto.java
@@ -27,9 +27,6 @@ public class NodeInfoDto {
     /** 绑定的操作控制项 */
     private List<NodeActionDto> actions;
 
-    /** 控制项名称列表 */
-    private List<String> actionTypes;
-
     /** 创建人ID */
     private Long creatorId;
     /** 创建人名称 */


### PR DESCRIPTION
## Summary
- drop obsolete action ids and type lists in node DTOs
- populate role names and real user names in node queries
- record creator and updater for node-role relations while relying on DB timestamps

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for org.jeecgframework.boot:jeecg-boot-parent:3.5.1: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.7.10)*

------
https://chatgpt.com/codex/tasks/task_e_68999d8f25fc833094601ee7be8a414d