### PR TITLE
feat: support filtering nodes by roleId

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeQueryDto.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeQueryDto.java
@@ -9,7 +9,7 @@ import lombok.Data;
 public class NodeQueryDto {
     private Integer status;
     private String name;
-    private String roleName;
+    private Long roleId;
 
     private Integer page = 1;
     private Integer pageSize = 20;

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcNodeServiceImpl.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcNodeServiceImpl.java
@@ -65,16 +65,10 @@ public class TcNodeServiceImpl implements TcNodeService {
         if (StringUtils.isNotBlank(queryDto.getName())) {
             wrapper.like(NodeInfo::getName, queryDto.getName());
         }
-        if (StringUtils.isNotBlank(queryDto.getRoleName())) {
-            List<SysRole> roles = sysRoleMapper.selectList(Wrappers.<SysRole>query()
-                    .like("role_name", queryDto.getRoleName()));
-            if (roles.isEmpty()) {
-                return new PageResult<>(queryDto.getPage(), queryDto.getPageSize(), 0, Collections.emptyList());
-            }
-            List<Long> roleIds = roles.stream().map(r -> Long.valueOf(r.getId())).collect(Collectors.toList());
+        if (queryDto.getRoleId() != null) {
             List<Long> nodeIds = nodeRoleRelMapper.selectList(Wrappers.<NodeRoleRel>lambdaQuery()
                             .eq(NodeRoleRel::getDelFlag, 0)
-                            .in(NodeRoleRel::getRoleId, roleIds))
+                            .eq(NodeRoleRel::getRoleId, queryDto.getRoleId()))
                     .stream().map(NodeRoleRel::getNodeId).collect(Collectors.toList());
             if (nodeIds.isEmpty()) {
                 return new PageResult<>(queryDto.getPage(), queryDto.getPageSize(), 0, Collections.emptyList());


### PR DESCRIPTION
## Summary
- allow querying nodes by roleId instead of roleName

## Testing
- `mvn -q -pl system/biz -am test -DskipTests=false` *(fails: Unknown host maven.aliyun.com)*

------
https://chatgpt.com/codex/tasks/task_e_6899a6dcca6c8330b3e900a557c8168f