### PR TITLE
feat: add task list tabs

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/task/controller/TaskController.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/task/controller/TaskController.java
@@ -1,0 +1,26 @@
+package com.zjlab.dataservice.modules.task.controller;
+
+import com.zjlab.dataservice.common.api.vo.Result;
+import com.zjlab.dataservice.modules.task.model.dto.TaskListQuery;
+import com.zjlab.dataservice.modules.task.model.vo.TaskListPageVO;
+import com.zjlab.dataservice.modules.task.service.TaskService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.annotation.Resource;
+
+/** 任务列表接口 */
+@RestController
+@RequestMapping("/task")
+public class TaskController {
+
+    @Resource
+    private TaskService taskService;
+
+    @GetMapping("/list")
+    public Result<TaskListPageVO> list(TaskListQuery query) {
+        TaskListPageVO page = taskService.listTasks(query);
+        return Result.ok(page);
+    }
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/task/enums/TaskStatusEnum.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/task/enums/TaskStatusEnum.java
@@ -1,0 +1,40 @@
+package com.zjlab.dataservice.modules.task.enums;
+
+/**
+ * 任务状态
+ * 0-运行中 / 1-结束 / 2-异常结束 / 3-取消
+ */
+public enum TaskStatusEnum {
+    RUNNING(0, "运行中"),
+    FINISHED(1, "结束"),
+    ABNORMAL_END(2, "异常结束"),
+    CANCELED(3, "取消");
+
+    private final int code;
+    private final String desc;
+
+    TaskStatusEnum(int code, String desc) {
+        this.code = code;
+        this.desc = desc;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getDesc() {
+        return desc;
+    }
+
+    public static TaskStatusEnum fromCode(Integer code) {
+        if (code == null) {
+            return null;
+        }
+        for (TaskStatusEnum status : values()) {
+            if (status.code == code) {
+                return status;
+            }
+        }
+        return null;
+    }
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/task/mapper/TaskMapper.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/task/mapper/TaskMapper.java
@@ -1,0 +1,17 @@
+package com.zjlab.dataservice.modules.task.mapper;
+
+import com.zjlab.dataservice.modules.task.model.dto.TaskListQuery;
+import com.zjlab.dataservice.modules.task.model.po.TaskListItemPO;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+/**
+ * 任务列表相关查询
+ */
+public interface TaskMapper {
+    /** 查询列表 */
+    List<TaskListItemPO> selectTaskList(@Param("query") TaskListQuery query);
+    /** 统计总数 */
+    Long countTaskList(@Param("query") TaskListQuery query);
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/task/mapper/xml/TaskMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/task/mapper/xml/TaskMapper.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.zjlab.dataservice.modules.task.mapper.TaskMapper">
+
+    <sql id="selectFields">
+        t.id AS taskId,
+        t.task_name AS taskName,
+        t.task_code AS taskCode,
+        JSON_OBJECT(
+            'templateId', t.template_id,
+            'templateName', tt.template_name
+        ) AS template,
+        t.satellites AS satellites,
+        t.create_time AS createTime,
+        t.status AS status,
+        COALESCE(curN.current_nodes_json, JSON_ARRAY()) AS currentNodes
+    </sql>
+
+    <sql id="joinCurrentNodes">
+        LEFT JOIN tc_todo_template tt ON tt.id = t.template_id
+        LEFT JOIN (
+            SELECT
+                ni.task_id,
+                JSON_ARRAYAGG(
+                    JSON_OBJECT(
+                        'nodeInstId', ni.id,
+                        'nodeName', ninfo.name,
+                        'roles',
+                        (
+                            SELECT JSON_ARRAYAGG(JSON_OBJECT('roleId', r.id, 'roleName', r.role_name))
+                            FROM JSON_TABLE(ni.handler_role_ids, '$[*]' COLUMNS (role_id VARCHAR(64) PATH '$')) jt
+                            JOIN sys_role r ON r.id = jt.role_id
+                        )
+                    )
+                    ORDER BY ni.order_no, ni.id
+                ) AS current_nodes_json
+            FROM tc_task_node_inst ni
+            JOIN tc_node_info ninfo ON ninfo.id = ni.node_id
+            WHERE ni.del_flag = 0 AND ni.status = 1
+            GROUP BY ni.task_id
+        ) curN ON curN.task_id = t.id
+    </sql>
+
+    <sql id="whereCommon">
+        t.del_flag = 0
+        <if test="query.q != null and query.q != ''">
+            AND (t.task_name LIKE CONCAT('%', #{query.q}, '%') OR t.task_code LIKE CONCAT('%', #{query.q}, '%'))
+        </if>
+        <if test="query.status != null">
+            AND t.status = #{query.status}
+        </if>
+        <if test="query.templateId != null">
+            AND t.template_id = #{query.templateId}
+        </if>
+        <if test="query.startTimeFrom != null">
+            AND t.create_time &gt;= #{query.startTimeFrom}
+        </if>
+    </sql>
+
+    <select id="selectTaskList" resultType="com.zjlab.dataservice.modules.task.model.po.TaskListItemPO">
+        <script>
+            SELECT
+            <include refid="selectFields"/>
+            FROM tc_task t
+            <if test="query.tab == 'todo' or query.tab == 'participated'">
+                JOIN tc_task_work_item w ON w.task_id = t.id
+            </if>
+            <if test="query.tab == 'handled'">
+                JOIN tc_task_work_item wi ON wi.task_id = t.id
+            </if>
+            <include refid="joinCurrentNodes"/>
+            WHERE
+            <include refid="whereCommon"/>
+            <if test="query.tab == 'startedByMe'">
+                AND t.create_by = #{query.userId}
+            </if>
+            <if test="query.tab == 'todo'">
+                AND w.del_flag = 0 AND w.assignee_id = #{query.userId} AND w.phase_status = 1
+            </if>
+            <if test="query.tab == 'participated'">
+                AND w.del_flag = 0 AND w.assignee_id = #{query.userId} AND w.phase_status = 0
+            </if>
+            <if test="query.tab == 'handled'">
+                AND wi.del_flag = 0 AND wi.phase_status = 2
+                AND wi.assignee_id IN (
+                    SELECT DISTINCT sur.user_id
+                    FROM sys_user_role sur
+                    WHERE sur.role_id IN (
+                        SELECT DISTINCT role_id FROM sys_user_role WHERE user_id = #{query.userId}
+                    )
+                )
+            </if>
+            ORDER BY t.create_time DESC
+            LIMIT #{query.offset}, #{query.pageSize}
+        </script>
+    </select>
+
+    <select id="countTaskList" resultType="long">
+        <script>
+            SELECT
+            <choose>
+                <when test="query.tab == 'todo' or query.tab == 'participated' or query.tab == 'handled'">
+                    COUNT(DISTINCT t.id)
+                </when>
+                <otherwise>
+                    COUNT(1)
+                </otherwise>
+            </choose>
+            FROM tc_task t
+            <if test="query.tab == 'todo' or query.tab == 'participated'">
+                JOIN tc_task_work_item w ON w.task_id = t.id
+            </if>
+            <if test="query.tab == 'handled'">
+                JOIN tc_task_work_item wi ON wi.task_id = t.id
+            </if>
+            WHERE
+            <include refid="whereCommon"/>
+            <if test="query.tab == 'startedByMe'">
+                AND t.create_by = #{query.userId}
+            </if>
+            <if test="query.tab == 'todo'">
+                AND w.del_flag = 0 AND w.assignee_id = #{query.userId} AND w.phase_status = 1
+            </if>
+            <if test="query.tab == 'participated'">
+                AND w.del_flag = 0 AND w.assignee_id = #{query.userId} AND w.phase_status = 0
+            </if>
+            <if test="query.tab == 'handled'">
+                AND wi.del_flag = 0 AND wi.phase_status = 2
+                AND wi.assignee_id IN (
+                    SELECT DISTINCT sur.user_id
+                    FROM sys_user_role sur
+                    WHERE sur.role_id IN (
+                        SELECT DISTINCT role_id FROM sys_user_role WHERE user_id = #{query.userId}
+                    )
+                )
+            </if>
+        </script>
+    </select>
+
+</mapper>

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/task/model/dto/TaskListQuery.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/task/model/dto/TaskListQuery.java
@@ -1,0 +1,32 @@
+package com.zjlab.dataservice.modules.task.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 查询任务列表的参数
+ */
+@Data
+public class TaskListQuery {
+    /** Tab类型：all/startedByMe/todo/participated/handled */
+    private String tab;
+    /** 模糊搜索：任务名称或编码 */
+    private String q;
+    /** 任务状态 */
+    private Integer status;
+    /** 模板ID */
+    private Long templateId;
+    /** 创建时间起 */
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime startTimeFrom;
+    /** 页码，默认1 */
+    private Integer page;
+    /** 每页条数，默认10 */
+    private Integer pageSize;
+    /** 当前登录用户ID */
+    private String userId;
+    /** 偏移量，内部计算 */
+    private Integer offset;
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/task/model/po/TaskListItemPO.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/task/model/po/TaskListItemPO.java
@@ -1,0 +1,23 @@
+package com.zjlab.dataservice.modules.task.model.po;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 任务列表查询结果的持久对象
+ */
+@Data
+public class TaskListItemPO {
+    private Long taskId;
+    private String taskName;
+    private String taskCode;
+    /** 模板对象JSON */
+    private String template;
+    /** 卫星JSON */
+    private String satellites;
+    private LocalDateTime createTime;
+    private Integer status;
+    /** 当前节点数组JSON */
+    private String currentNodes;
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/task/model/vo/CurrentNodeVO.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/task/model/vo/CurrentNodeVO.java
@@ -1,0 +1,14 @@
+package com.zjlab.dataservice.modules.task.model.vo;
+
+import com.zjlab.dataservice.modules.tc.model.dto.NodeRoleDto;
+import lombok.Data;
+
+import java.util.List;
+
+/** 当前激活节点信息 */
+@Data
+public class CurrentNodeVO {
+    private Long nodeInstId;
+    private String nodeName;
+    private List<NodeRoleDto> roles;
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/task/model/vo/TaskListItemVO.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/task/model/vo/TaskListItemVO.java
@@ -1,0 +1,20 @@
+package com.zjlab.dataservice.modules.task.model.vo;
+
+import com.zjlab.dataservice.modules.task.enums.TaskStatusEnum;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/** 任务列表的返回对象 */
+@Data
+public class TaskListItemVO {
+    private Long taskId;
+    private String taskName;
+    private String taskCode;
+    private TemplateVO template;
+    private String satellites;
+    private LocalDateTime createTime;
+    private TaskStatusEnum status;
+    private List<CurrentNodeVO> currentNodes;
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/task/model/vo/TaskListPageVO.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/task/model/vo/TaskListPageVO.java
@@ -1,0 +1,16 @@
+package com.zjlab.dataservice.modules.task.model.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/** 任务列表分页返回 */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TaskListPageVO {
+    private List<TaskListItemVO> list;
+    private Long total;
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/task/model/vo/TemplateVO.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/task/model/vo/TemplateVO.java
@@ -1,0 +1,10 @@
+package com.zjlab.dataservice.modules.task.model.vo;
+
+import lombok.Data;
+
+/** 模板信息 */
+@Data
+public class TemplateVO {
+    private Long templateId;
+    private String templateName;
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/task/service/TaskService.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/task/service/TaskService.java
@@ -1,0 +1,14 @@
+package com.zjlab.dataservice.modules.task.service;
+
+import com.zjlab.dataservice.modules.task.model.dto.TaskListQuery;
+import com.zjlab.dataservice.modules.task.model.vo.TaskListPageVO;
+
+/**
+ * 任务相关服务
+ */
+public interface TaskService {
+    /**
+     * 分页查询任务列表
+     */
+    TaskListPageVO listTasks(TaskListQuery query);
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/task/service/impl/TaskServiceImpl.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/task/service/impl/TaskServiceImpl.java
@@ -1,0 +1,67 @@
+package com.zjlab.dataservice.modules.task.service.impl;
+
+import com.alibaba.fastjson.JSON;
+import com.zjlab.dataservice.common.system.vo.LoginUser;
+import com.zjlab.dataservice.modules.task.enums.TaskStatusEnum;
+import com.zjlab.dataservice.modules.task.mapper.TaskMapper;
+import com.zjlab.dataservice.modules.task.model.dto.TaskListQuery;
+import com.zjlab.dataservice.modules.task.model.po.TaskListItemPO;
+import com.zjlab.dataservice.modules.task.model.vo.CurrentNodeVO;
+import com.zjlab.dataservice.modules.task.model.vo.TaskListItemVO;
+import com.zjlab.dataservice.modules.task.model.vo.TaskListPageVO;
+import com.zjlab.dataservice.modules.task.model.vo.TemplateVO;
+import com.zjlab.dataservice.modules.task.service.TaskService;
+import org.apache.shiro.SecurityUtils;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Resource;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 任务相关服务实现
+ */
+@Service
+public class TaskServiceImpl implements TaskService {
+
+    @Resource
+    private TaskMapper taskMapper;
+
+    @Override
+    public TaskListPageVO listTasks(TaskListQuery query) {
+        Object principal = SecurityUtils.getSubject().getPrincipal();
+        if (principal instanceof LoginUser) {
+            query.setUserId(((LoginUser) principal).getId());
+        }
+
+        if (query.getPage() == null || query.getPage() < 1) {
+            query.setPage(1);
+        }
+        if (query.getPageSize() == null || query.getPageSize() < 1) {
+            query.setPageSize(10);
+        }
+        query.setOffset((query.getPage() - 1) * query.getPageSize());
+
+        List<TaskListItemPO> pos = taskMapper.selectTaskList(query);
+        List<TaskListItemVO> vos = new ArrayList<>();
+        for (TaskListItemPO po : pos) {
+            TaskListItemVO vo = new TaskListItemVO();
+            vo.setTaskId(po.getTaskId());
+            vo.setTaskName(po.getTaskName());
+            vo.setTaskCode(po.getTaskCode());
+            if (po.getTemplate() != null) {
+                vo.setTemplate(JSON.parseObject(po.getTemplate(), TemplateVO.class));
+            }
+            vo.setSatellites(po.getSatellites());
+            vo.setCreateTime(po.getCreateTime());
+            vo.setStatus(TaskStatusEnum.fromCode(po.getStatus()));
+            if (po.getCurrentNodes() != null) {
+                List<CurrentNodeVO> nodes = JSON.parseArray(po.getCurrentNodes(), CurrentNodeVO.class);
+                vo.setCurrentNodes(nodes);
+            }
+            vos.add(vo);
+        }
+        long total = taskMapper.countTaskList(query);
+        return new TaskListPageVO(vos, total);
+    }
+}


### PR DESCRIPTION
## Summary
- add task list query DTO, VOs, mapper, service, controller
- implement GET /task/list with five tabs and dynamic SQL
- move user lookup into service layer and replace RoleVO with NodeRoleDto
- introduce TaskStatusEnum for task item status codes

## Testing
- `mvn -q -pl system/biz -am test` *(fails: Non-resolvable parent POM)*


------
https://chatgpt.com/codex/tasks/task_e_68a44d9342a48330872923b12978626b