### PR TITLE
refactor: unify task work item join in TaskManagerMapper

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TaskManagerMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TaskManagerMapper.xml
@@ -61,10 +61,7 @@
         SELECT
         <include refid="selectFields"/>
         FROM tc_task t
-        <if test="query.tab == 'todo' or query.tab == 'participated'">
-            JOIN tc_task_work_item w ON w.task_id = t.id
-        </if>
-        <if test="query.tab == 'handled'">
+        <if test="query.tab == 'todo' or query.tab == 'participated' or query.tab == 'handled'">
             JOIN tc_task_work_item wi ON wi.task_id = t.id
         </if>
         <include refid="joinCurrentNodes"/>
@@ -74,10 +71,10 @@
             AND t.create_by = #{query.userId}
         </if>
         <if test="query.tab == 'todo'">
-            AND w.del_flag = 0 AND w.assignee_id = #{query.userId} AND w.phase_status = 1
+            AND wi.del_flag = 0 AND wi.assignee_id = #{query.userId} AND wi.phase_status = 1
         </if>
         <if test="query.tab == 'participated'">
-            AND w.del_flag = 0 AND w.assignee_id = #{query.userId} AND w.phase_status = 0
+            AND wi.del_flag = 0 AND wi.assignee_id = #{query.userId} AND wi.phase_status = 0
         </if>
         <if test="query.tab == 'handled'">
             AND wi.del_flag = 0 AND wi.assignee_id = #{query.userId}
@@ -98,10 +95,7 @@
             </otherwise>
         </choose>
         FROM tc_task t
-        <if test="query.tab == 'todo' or query.tab == 'participated'">
-            JOIN tc_task_work_item w ON w.task_id = t.id
-        </if>
-        <if test="query.tab == 'handled'">
+        <if test="query.tab == 'todo' or query.tab == 'participated' or query.tab == 'handled'">
             JOIN tc_task_work_item wi ON wi.task_id = t.id
         </if>
         WHERE
@@ -110,10 +104,10 @@
             AND t.create_by = #{query.userId}
         </if>
         <if test="query.tab == 'todo'">
-            AND w.del_flag = 0 AND w.assignee_id = #{query.userId} AND w.phase_status = 1
+            AND wi.del_flag = 0 AND wi.assignee_id = #{query.userId} AND wi.phase_status = 1
         </if>
         <if test="query.tab == 'participated'">
-            AND w.del_flag = 0 AND w.assignee_id = #{query.userId} AND w.phase_status = 0
+            AND wi.del_flag = 0 AND wi.assignee_id = #{query.userId} AND wi.phase_status = 0
         </if>
         <if test="query.tab == 'handled'">
             AND wi.del_flag = 0 AND wi.assignee_id = #{query.userId}


### PR DESCRIPTION
## Summary
- simplify TaskManagerMapper by using a single work item alias and tab-specific filters

## Testing
- `mvn -q -pl system/biz -am test` *(fails: Non-resolvable parent POM; Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.7.10 from/to aliyun: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a53466a230833093575c43c702d5c2