### PR TITLE
Optimize task list node join for large tables

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TaskManagerMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TaskManagerMapper.xml
@@ -18,9 +18,8 @@
 
     <sql id="joinCurrentNodes">
         LEFT JOIN tc_todo_template tt ON tt.id = t.template_id
-        LEFT JOIN (
+        LEFT JOIN LATERAL (
             SELECT
-                ni.task_id,
                 JSON_ARRAYAGG(
                     JSON_OBJECT(
                         'nodeInstId', ni.id,
@@ -36,9 +35,8 @@
                 ) AS current_nodes_json
             FROM tc_task_node_inst ni
             JOIN tc_node_info ninfo ON ninfo.id = ni.node_id
-            WHERE ni.del_flag = 0 AND ni.status = 1
-            GROUP BY ni.task_id
-        ) curN ON curN.task_id = t.id
+            WHERE ni.del_flag = 0 AND ni.status = 1 AND ni.task_id = t.id
+        ) curN ON TRUE
     </sql>
 
     <sql id="whereCommon">
@@ -60,28 +58,31 @@
     <select id="selectTaskList" resultType="com.zjlab.dataservice.modules.tc.model.vo.TaskManagerListItemVO">
         SELECT
         <include refid="selectFields"/>
-        FROM tc_task t
-        <if test="query.tab == 'todo' or query.tab == 'participated' or query.tab == 'handled'">
-            JOIN tc_task_work_item wi ON wi.task_id = t.id
-        </if>
+        FROM (
+            SELECT t.*
+            FROM tc_task t
+            <if test="query.tab == 'todo' or query.tab == 'participated' or query.tab == 'handled'">
+                JOIN tc_task_work_item wi ON wi.task_id = t.id
+            </if>
+            WHERE
+            <include refid="whereCommon"/>
+            <if test="query.tab == 'startedByMe'">
+                AND t.create_by = #{query.userId}
+            </if>
+            <if test="query.tab == 'todo'">
+                AND wi.del_flag = 0 AND wi.assignee_id = #{query.userId} AND wi.phase_status = 1
+            </if>
+            <if test="query.tab == 'participated'">
+                AND wi.del_flag = 0 AND wi.assignee_id = #{query.userId} AND wi.phase_status = 0
+            </if>
+            <if test="query.tab == 'handled'">
+                AND wi.del_flag = 0 AND wi.assignee_id = #{query.userId}
+                AND wi.phase_status IN (2,4)
+            </if>
+            ORDER BY t.create_time DESC
+            LIMIT #{query.offset}, #{query.pageSize}
+        ) t
         <include refid="joinCurrentNodes"/>
-        WHERE
-        <include refid="whereCommon"/>
-        <if test="query.tab == 'startedByMe'">
-            AND t.create_by = #{query.userId}
-        </if>
-        <if test="query.tab == 'todo'">
-            AND wi.del_flag = 0 AND wi.assignee_id = #{query.userId} AND wi.phase_status = 1
-        </if>
-        <if test="query.tab == 'participated'">
-            AND wi.del_flag = 0 AND wi.assignee_id = #{query.userId} AND wi.phase_status = 0
-        </if>
-        <if test="query.tab == 'handled'">
-            AND wi.del_flag = 0 AND wi.assignee_id = #{query.userId}
-            AND wi.phase_status IN (2,4)
-        </if>
-        ORDER BY t.create_time DESC
-        LIMIT #{query.offset}, #{query.pageSize}
     </select>
 
     <select id="countTaskList" resultType="long">


### PR DESCRIPTION
## Summary
- Fetch task nodes with a lateral join scoped to each task
- Paginate task list before joining template and node data

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5363049988330bf30db3dcba81cbd