### PR TITLE
docs: add template node composite indexes

### DIFF
--- a/doc/ddl.md
+++ b/doc/ddl.md
@@ -124,7 +124,9 @@ CREATE TABLE `tc_task_template_node` (
   `update_by` BIGINT,
   `update_time` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   CHECK (`prev_keys` IS NULL OR JSON_VALID(`prev_keys`)),
-  CHECK (`next_keys` IS NULL OR JSON_VALID(`next_keys`))
+  CHECK (`next_keys` IS NULL OR JSON_VALID(`next_keys`)),
+  INDEX `idx_template_node` (`template_id`, `node_id`),
+  INDEX `idx_template_order` (`template_id`, `order_no`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='任务模板-节点定义表';
 ```
 


### PR DESCRIPTION
## Summary
- document composite indexes for `tc_task_template_node` to accelerate lookups and ordering

## Testing
- `mvn -q -ntp test` *(fails: Non-resolvable parent POM; network is unreachable)*
- `mysql -h localhost -u root -proot -e "ALTER TABLE tc_task_template_node ADD INDEX ..."` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a53ce40f7883309f3ee239c883c100