### PR TITLE
chore: remove roles field and streamline mock login header

### DIFF
--- a/common/src/main/java/com/zjlab/dataservice/common/system/vo/LoginUser.java
+++ b/common/src/main/java/com/zjlab/dataservice/common/system/vo/LoginUser.java
@@ -42,14 +42,8 @@ public class LoginUser {
 	@SensitiveField
 	private String realname;
         /**
-         * 逗号分隔的角色ID
+         * 登录人密码
          */
-        private String roles;
-
-
-	/**
-	 * 登录人密码
-	 */
 	@SensitiveField
 	private String password;
 

--- a/common/src/main/java/com/zjlab/dataservice/config/Swagger2Config.java
+++ b/common/src/main/java/com/zjlab/dataservice/config/Swagger2Config.java
@@ -99,6 +99,11 @@ public class Swagger2Config implements WebMvcConfigurer {
         List<Parameter> pars = new ArrayList<>();
         tokenPar.name(CommonConstant.X_ACCESS_TOKEN).description("token").modelRef(new ModelRef("string")).parameterType("header").required(false).build();
         pars.add(tokenPar.build());
+
+        ParameterBuilder mockUserPar = new ParameterBuilder();
+        mockUserPar.name("X-Mock-UserId").description("mock user id").modelRef(new ModelRef("string")).parameterType("header").required(false).build();
+        pars.add(mockUserPar.build());
+
         return pars;
     }
 

--- a/doc/taskManager.md
+++ b/doc/taskManager.md
@@ -431,7 +431,7 @@ WHERE t.del_flag=0
 #### 2.2.6 Swagger 调试：Mock 登录（Shiro）
 
 SecurityUtils.getSubject().getPrincipal() 在 Swagger 下为空时，启用开发环境 Mock。
-通过请求头注入：X-Mock-UserId, X-Mock-Username, X-Mock-Roles（逗号分隔）。
+通过请求头注入：X-Mock-UserId。
 ```java
 @Profile({"dev","swagger"})
 @Component
@@ -445,14 +445,11 @@ public class MockLoginFilter extends OncePerRequestFilter {
             chain.doFilter(req, res); return;
         }
         String uid = req.getHeader("X-Mock-UserId");
-        String uname = req.getHeader("X-Mock-Username");
-        String rolesCsv = req.getHeader("X-Mock-Roles");
         if (uid != null && securityManager != null) {
             LoginUser mock = new LoginUser();
             mock.setId(uid);
-            mock.setUsername(uname != null ? uname : "swagger");
-            mock.setRealname(uname != null ? uname : "swagger");
-            mock.setRoles(rolesCsv);
+            mock.setUsername(uid);
+            mock.setRealname(uid);
             Subject subject = new Subject.Builder(securityManager).buildSubject();
             PrincipalCollection pc = new SimplePrincipalCollection(mock, "mockRealm");
             subject.runAs(pc);
@@ -466,8 +463,6 @@ public class MockLoginFilter extends OncePerRequestFilter {
 **使用方式（Swagger 调试时加请求头）**
 
 * X-Mock-UserId: 10001
-* X-Mock-Username: swagger
-* X-Mock-Roles: 1,3
 
 #### 2.2.7 小结
 

--- a/system/biz/src/main/java/com/zjlab/dataservice/config/MockLoginFilter.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/config/MockLoginFilter.java
@@ -36,14 +36,11 @@ public class MockLoginFilter extends OncePerRequestFilter {
             return;
         }
         String uid = req.getHeader("X-Mock-UserId");
-        String uname = req.getHeader("X-Mock-Username");
-        String rolesCsv = req.getHeader("X-Mock-Roles");
         if (uid != null && securityManager != null) {
             LoginUser mock = new LoginUser();
             mock.setId(uid);
-            mock.setUsername(uname != null ? uname : "swagger");
-            mock.setRealname(uname != null ? uname : "swagger");
-            mock.setRoles(rolesCsv);
+            mock.setUsername(uid);
+            mock.setRealname(uid);
             Subject subject = new Subject.Builder(securityManager).buildSubject();
             PrincipalCollection pc = new SimplePrincipalCollection(mock, "mockRealm");
             subject.runAs(pc);


### PR DESCRIPTION
## Summary
- remove unused roles field from LoginUser
- simplify MockLoginFilter to derive username from user ID and drop X-Mock-Username header
- expose optional X-Mock-UserId as a global Swagger header parameter

## Testing
- `mvn -q -pl common,system -am test` *(fails: Non-resolvable parent POM for org.jeecgframework.boot:jeecg-boot-parent:3.5.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a5428c8d288330b7ccd884aeb71b7b