### PR TITLE
chore: upgrade mybatis plus and jsqlparser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,11 +48,12 @@
 		<mysql-connector-java.version>8.0.27</mysql-connector-java.version>
 		<hutool.version>5.3.8</hutool.version>
 
-		<!-- 持久层 -->
-		<mybatis-plus.version>3.5.1</mybatis-plus.version>
-		<dynamic-datasource-spring-boot-starter.version>3.2.0</dynamic-datasource-spring-boot-starter.version>
-		<druid.version>1.1.22</druid.version>
-		<minidao.version>1.9.0</minidao.version>
+                <!-- 持久层 -->
+                <mybatis-plus.version>3.5.3.2</mybatis-plus.version>
+                <dynamic-datasource-spring-boot-starter.version>3.2.0</dynamic-datasource-spring-boot-starter.version>
+                <druid.version>1.1.22</druid.version>
+                <minidao.version>1.9.0</minidao.version>
+                <jsqlparser.version>4.6</jsqlparser.version>
 
 		<!-- 积木报表-->
 		<jimureport-spring-boot-starter.version>1.5.6</jimureport-spring-boot-starter.version>
@@ -324,13 +325,18 @@
 					</exclusion>
 				</exclusions>
 			</dependency>
-			<dependency>
-				<groupId>org.jeecgframework.jimureport</groupId>
-				<artifactId>jimureport-nosql-starter</artifactId>
-				<version>${jimureport-spring-boot-starter.version}</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
+                        <dependency>
+                                <groupId>org.jeecgframework.jimureport</groupId>
+                                <artifactId>jimureport-nosql-starter</artifactId>
+                                <version>${jimureport-spring-boot-starter.version}</version>
+                        </dependency>
+                        <dependency>
+                                <groupId>com.github.jsqlparser</groupId>
+                                <artifactId>jsqlparser</artifactId>
+                                <version>${jsqlparser.version}</version>
+                        </dependency>
+                </dependencies>
+        </dependencyManagement>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
## Summary
- upgrade mybatis-plus to 3.5.3.2
- add explicit jsqlparser 4.6 dependency

## Testing
- `mvn -q -e -pl common -am test -DskipTests` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.7.10 from/to aliyun: Name or service not known)*

------
https://chatgpt.com/codex/tasks/task_e_68a56e91c7c483309637e90936f44387