### PR TITLE
fix: remove lateral join in task query

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskManagerMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskManagerMapper.xml
@@ -18,8 +18,9 @@
 
     <sql id="joinCurrentNodes">
         LEFT JOIN tc_todo_template tt ON tt.id = t.template_id
-        LEFT JOIN LATERAL (
+        LEFT JOIN (
             SELECT
+                ni.task_id,
                 JSON_ARRAYAGG(
                     JSON_OBJECT(
                         'nodeInstId', ni.id,
@@ -35,8 +36,9 @@
                 ) AS current_nodes_json
             FROM tc_task_node_inst ni
             JOIN tc_node_info ninfo ON ninfo.id = ni.node_id
-            WHERE ni.del_flag = 0 AND ni.status = 1 AND ni.task_id = t.id
-        ) curN ON TRUE
+            WHERE ni.del_flag = 0 AND ni.status = 1
+            GROUP BY ni.task_id
+        ) curN ON curN.task_id = t.id
     </sql>
 
     <sql id="whereCommon">


### PR DESCRIPTION
## Summary
- avoid using LATERAL join in task listing query to support older MySQL versions

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:2.7.10)*

------
https://chatgpt.com/codex/tasks/task_e_68a57ba5307483308a589a87a6b892c2