### PR TITLE
refactor: use integer status in task list

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/vo/TaskManagerListItemVO.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/vo/TaskManagerListItemVO.java
@@ -1,6 +1,5 @@
 package com.zjlab.dataservice.modules.tc.model.vo;
 
-import com.zjlab.dataservice.modules.tc.enums.TaskManagerStatusEnum;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -16,6 +15,6 @@ public class TaskManagerListItemVO {
     private String templateName;
     private String satellites;
     private LocalDateTime createTime;
-    private TaskManagerStatusEnum status;
+    private Integer status;
     private List<CurrentNodeVO> currentNodes;
 }


### PR DESCRIPTION
## Summary
- remove TaskManager status enum type handler
- return raw integer status in task list results

## Testing
- `mvn -q -pl system -am test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a599d076b88330acb0ea67e774bf77