### PR TITLE
fix: validate task manager list params

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcTaskManagerController.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcTaskManagerController.java
@@ -7,9 +7,12 @@ import com.zjlab.dataservice.modules.tc.model.dto.TaskManagerListQuery;
 import com.zjlab.dataservice.modules.tc.model.vo.TaskManagerListItemVO;
 import com.zjlab.dataservice.modules.tc.service.TcTaskManagerService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -20,6 +23,7 @@ import javax.annotation.Resource;
 @RestController
 @RequestMapping("/tc/taskManager")
 @Api(tags="任务管理")
+@Validated
 public class TcTaskManagerController {
 
     @Autowired
@@ -28,7 +32,7 @@ public class TcTaskManagerController {
     @GetMapping("/list")
     @ApiOperationSupport(order = 1)
     @ApiOperation(value="任务列表", notes="分页查询任务列表")
-    public Result<PageResult<TaskManagerListItemVO>> list(TaskManagerListQuery query) {
+    public Result<PageResult<TaskManagerListItemVO>> list(@Valid TaskManagerListQuery query) {
         return Result.ok(taskManagerService.listTasks(query));
     }
 }

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/TaskManagerListQuery.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/TaskManagerListQuery.java
@@ -2,7 +2,10 @@ package com.zjlab.dataservice.modules.tc.model.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 import java.time.LocalDateTime;
 
 /**
@@ -10,7 +13,9 @@ import java.time.LocalDateTime;
  */
 @Data
 public class TaskManagerListQuery {
-    /** Tab类型：all/startedByMe/todo/participated/handled */
+    /** Tab类型：all/startedByMe/todo/handled/participated */
+    @NotBlank(message = "tab不能为空")
+    @Pattern(regexp = "all|startedByMe|todo|handled|participated", message = "tab必须为all/startedByMe/todo/handled/participated")
     private String tab;
     /** 模糊搜索：任务名称或编码 */
     private String q;
@@ -19,6 +24,7 @@ public class TaskManagerListQuery {
     /** 模板ID */
     private Long templateId;
     /** 创建时间起 */
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime startTimeFrom;
     /** 页码，默认1 */

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
@@ -1,6 +1,8 @@
 package com.zjlab.dataservice.modules.tc.service.impl;
 
 import com.zjlab.dataservice.common.api.page.PageResult;
+import com.zjlab.dataservice.common.constant.enums.ResultCode;
+import com.zjlab.dataservice.common.exception.BaseException;
 import com.zjlab.dataservice.common.system.vo.LoginUser;
 import com.alibaba.fastjson.JSON;
 import com.zjlab.dataservice.modules.tc.mapper.TcTaskManagerMapper;
@@ -45,6 +47,10 @@ public class TcTaskManagerServiceImpl implements TcTaskManagerService {
         Object principal = SecurityUtils.getSubject().getPrincipal();
         if (principal instanceof LoginUser) {
             query.setUserId(((LoginUser) principal).getId());
+        }
+
+        if (StringUtils.isBlank(query.getUserId())) {
+            throw new BaseException(ResultCode.USERID_IS_NULL);
         }
 
         if (query.getPage() == null || query.getPage() < 1) {


### PR DESCRIPTION
## Summary
- fix startTimeFrom request param conversion
- enforce tab field validation for task list
- ensure user identity is present when listing tasks
- allow `startedByMe` as a valid tab option

## Testing
- `mvn -pl system/biz -am test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a67e830fe08330b446ab0bd426714e