### PR TITLE
refactor: use string for templateId

### DIFF
--- a/doc/ddl.md
+++ b/doc/ddl.md
@@ -112,7 +112,7 @@ CREATE TABLE `tc_todo_template` (
 ```sql
 CREATE TABLE `tc_task_template_node` (
   `id` BIGINT PRIMARY KEY AUTO_INCREMENT COMMENT '模板节点记录ID',
-  `template_id` BIGINT NOT NULL COMMENT '任务模板ID',
+  `template_id` varchar(128) NOT NULL COMMENT '任务模板ID',
   `node_id` BIGINT NOT NULL COMMENT '节点ID',
   `order_no` INT COMMENT '层级序号',
   `prev_keys` JSON COMMENT '前驱节点键数组',
@@ -140,7 +140,7 @@ CREATE TABLE `tc_task` (
   `task_code` VARCHAR(50) NOT NULL COMMENT '任务编码',
   `task_name` VARCHAR(50) NOT NULL COMMENT '任务名称',
   `task_requirement` VARCHAR(255) COMMENT '任务需求',
-  `template_id` BIGINT COMMENT '任务模板ID',
+  `template_id` varchar(128) NOT NULL COMMENT '任务模板ID',
   `need_imaging` TINYINT DEFAULT 0 COMMENT '是否需要成像(0否,1是)',
   `imaging_area` JSON NULL COMMENT '成像区域JSON',
   `result_display_needed` TINYINT DEFAULT 0 COMMENT '结果是否展示(0否,1是)',
@@ -166,7 +166,7 @@ CREATE TABLE `tc_task` (
 CREATE TABLE `tc_task_node_inst` (
   `id` BIGINT PRIMARY KEY AUTO_INCREMENT COMMENT '节点实例ID',
   `task_id` BIGINT NOT NULL COMMENT '任务ID',
-  `template_id` BIGINT NOT NULL COMMENT '任务模板ID',
+  `template_id` varchar(128) NOT NULL COMMENT '任务模板ID',
   `node_id` BIGINT NOT NULL COMMENT '节点ID',
   `prev_node_ids` JSON COMMENT '前驱节点实例ID数组',
   `next_node_ids` JSON COMMENT '后继节点实例ID数组',

--- a/doc/taskManager.md
+++ b/doc/taskManager.md
@@ -28,7 +28,7 @@ DDL 已在总文档（画布）中，这里只列编码相关字段与含义。
 * **tc\_task\_template\_node**：模板节点（不含办理角色）
 
   * id：模板节点ID（唯一，用于前驱/后继连边键）
-  * template\_id：模板ID
+  * template\_id：模板ID（string，必填）
   * node\_id：节点定义ID（tc\_node\_info.id）
   * order\_no：层序（可空）
   * prev\_keys / next\_keys：数组，存放模板节点ID
@@ -42,13 +42,13 @@ DDL 已在总文档（画布）中，这里只列编码相关字段与含义。
 ### 1.3 任务运行域（运行态）
 
 * **tc\_task**
-  task\_code, task\_name, task\_requirement(<=255), template\_id
+  task\_code, task\_name, task\_requirement(<=255), template\_id(string，必填)
   need\_imaging, imaging\_area(JSON|null), result\_display\_needed
   satellites(JSON 二级结构), remote\_cmds(JSON), orbit\_plans(JSON)
   status：0运行中 / 1结束 / 2异常结束 / 3取消
 
 * **tc\_task\_node\_inst**
-  task\_id, template\_id, node\_id
+  task\_id, template\_id(string，必填), node\_id
   prev\_node\_ids(JSON) / next\_node\_ids(JSON)：实例ID数组
   arrived\_count：到达前驱计数
   handler\_role\_ids(JSON)：办理角色ID数组快照
@@ -176,7 +176,7 @@ TODO：当管理员判定规则明确后，在 tab=all 的入口做权限校验�
 | tab           | string   | 是   | 枚举：all / startedByMe / todo / participated / handled |
 | q             | string   | 否   | 模糊搜索：任务名称或任务编码          |
 | status        | int      | 否   | 任务状态：0运行中，1结束，2异常结束，3取消 |
-| templateId    | long     | 否   | 任务类型（模板ID）                    |
+| templateId    | string   | 否   | 任务类型（模板ID）                    |
 | startTimeFrom | datetime | 否   | 创建时间起（含）                      |
 | page          | int      | 否   | 页码，默认 1                         |
 | pageSize      | int      | 否   | 每页条数，默认 10                     |
@@ -188,7 +188,7 @@ TODO：当管理员判定规则明确后，在 tab=all 的入口做权限校验�
   "taskId": 123,
   "taskName": "应急成像-京津冀",
   "taskCode": "T2025-0001",
-  "template": { "templateId": 4, "templateName": "应急成像模板" },
+  "template": { "templateId": "TPL-0004", "templateName": "应急成像模板" },
   "satellites": [{"group":"三体星座","satIds":[1,2]}],
   "createTime": "2025-08-01 10:20:30",
   "status": 0,

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/TaskManagerListQuery.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/TaskManagerListQuery.java
@@ -22,7 +22,7 @@ public class TaskManagerListQuery {
     /** 任务状态 */
     private Integer status;
     /** 模板ID */
-    private Long templateId;
+    private String templateId;
     /** 创建时间起 */
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/vo/TaskManagerListItemVO.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/vo/TaskManagerListItemVO.java
@@ -11,7 +11,7 @@ public class TaskManagerListItemVO {
     private Long taskId;
     private String taskName;
     private String taskCode;
-    private Long templateId;
+    private String templateId;
     private String templateName;
     private String satellites;
     private LocalDateTime createTime;


### PR DESCRIPTION
## Summary
- use string templateId in task list DTO/VO
- document template_id columns as varchar(128) NOT NULL
- note string templateId in task manager spec and mark template_id required

## Testing
- `mvn -q -pl system/biz -am test` *(fails: Non-resolvable parent POM: Unknown host maven.aliyun.com)*

------
https://chatgpt.com/codex/tasks/task_e_68a68faca3248330a1d99779543e2fdf