### PR TITLE
feat: use varchar ids for tc audit fields

### DIFF
--- a/doc/ddl.md
+++ b/doc/ddl.md
@@ -119,9 +119,9 @@ CREATE TABLE `tc_task_template_node` (
   `next_keys` JSON COMMENT '后继节点键数组',
   `max_duration` INT COMMENT '最大时长（分钟）',
   `del_flag` TINYINT DEFAULT 0 COMMENT '删除标记：0正常，1删除',
-  `create_by` BIGINT,
+  `create_by` varchar(32) DEFAULT NULL COMMENT '创建人',
   `create_time` DATETIME DEFAULT CURRENT_TIMESTAMP,
-  `update_by` BIGINT,
+  `update_by` varchar(32) DEFAULT NULL COMMENT '更新人',
   `update_time` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   CHECK (`prev_keys` IS NULL OR JSON_VALID(`prev_keys`)),
   CHECK (`next_keys` IS NULL OR JSON_VALID(`next_keys`))
@@ -149,9 +149,9 @@ CREATE TABLE `tc_task` (
   `orbit_plans` JSON COMMENT '轨道计划JSON数组',
   `status` TINYINT NOT NULL DEFAULT 0 COMMENT '任务状态(0运行中,1结束,2异常结束,3取消)',
   `del_flag` TINYINT DEFAULT 0 COMMENT '删除标记：0正常，1删除',
-  `create_by` BIGINT,
+  `create_by` varchar(32) DEFAULT NULL COMMENT '创建人',
   `create_time` DATETIME DEFAULT CURRENT_TIMESTAMP,
-  `update_by` BIGINT,
+  `update_by` varchar(32) DEFAULT NULL COMMENT '更新人',
   `update_time` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   CHECK (`imaging_area` IS NULL OR JSON_VALID(`imaging_area`)),
   CHECK (`satellites` IS NULL OR JSON_VALID(`satellites`)),
@@ -179,9 +179,9 @@ CREATE TABLE `tc_task_node_inst` (
   `max_duration` INT COMMENT '最大时长（分钟）',
   `completed_by` BIGINT COMMENT '最终完成该节点的用户ID',
   `del_flag` TINYINT DEFAULT 0 COMMENT '删除标记：0正常，1删除',
-  `create_by` BIGINT,
+  `create_by` varchar(32) DEFAULT NULL COMMENT '创建人',
   `create_time` DATETIME DEFAULT CURRENT_TIMESTAMP,
-  `update_by` BIGINT,
+  `update_by` varchar(32) DEFAULT NULL COMMENT '更新人',
   `update_time` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   CHECK (`prev_node_ids` IS NULL OR JSON_VALID(`prev_node_ids`)),
   CHECK (`next_node_ids` IS NULL OR JSON_VALID(`next_node_ids`)),
@@ -199,9 +199,9 @@ CREATE TABLE `tc_task_work_item` (
   `assignee_id` BIGINT NOT NULL COMMENT '用户ID',
   `phase_status` TINYINT NOT NULL DEFAULT 0 COMMENT '阶段(0候选未到达,1待办,2我已处理,3任务取消撤销,4他人已完成失效)',
   `del_flag` TINYINT DEFAULT 0 COMMENT '删除标记：0正常，1删除',
-  `create_by` BIGINT,
+  `create_by` varchar(32) DEFAULT NULL COMMENT '创建人',
   `create_time` DATETIME DEFAULT CURRENT_TIMESTAMP,
-  `update_by` BIGINT,
+  `update_by` varchar(32) DEFAULT NULL COMMENT '更新人',
   `update_time` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='任务工作项';
 ```
@@ -216,9 +216,9 @@ CREATE TABLE `tc_task_node_action_record` (
   `action_type` TINYINT NOT NULL COMMENT '操作类型(0上传,1选择计划,2决策,3文本等)',
   `action_payload` JSON COMMENT '提交内容JSON',
   `del_flag` TINYINT DEFAULT 0 COMMENT '删除标记：0正常，1删除',
-  `create_by` BIGINT COMMENT '提交人ID',
+  `create_by` varchar(32) DEFAULT NULL COMMENT '创建人',
   `create_time` DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT '提交时间',
-  `update_by` BIGINT,
+  `update_by` varchar(32) DEFAULT NULL COMMENT '更新人',
   `update_time` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   CHECK (`action_payload` IS NULL OR JSON_VALID(`action_payload`))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='节点操作记录';
@@ -240,9 +240,9 @@ CREATE TABLE `tc_node_info` (
   `status` TINYINT DEFAULT 1 COMMENT '节点状态(1活跃,0禁用)',
   `actions` JSON NOT NULL COMMENT '操作控制项数组：[{type,name,config}]',
   `del_flag` TINYINT DEFAULT 0 COMMENT '删除标记(0正常,1删除)',
-  `create_by` BIGINT COMMENT '创建人ID',
+  `create_by` varchar(32) DEFAULT NULL COMMENT '创建人',
   `create_time` DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-  `update_by` BIGINT COMMENT '更新人ID',
+  `update_by` varchar(32) DEFAULT NULL COMMENT '更新人',
   `update_time` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='节点信息表';
 ```
@@ -255,9 +255,9 @@ CREATE TABLE `tc_node_role_rel` (
   `node_id` BIGINT NOT NULL COMMENT '节点ID',
   `role_id` BIGINT NOT NULL COMMENT '角色ID',
   `del_flag` TINYINT DEFAULT 0 COMMENT '删除标记(0正常,1删除)',
-  `create_by` BIGINT COMMENT '创建人ID',
+  `create_by` varchar(32) DEFAULT NULL COMMENT '创建人',
   `create_time` DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-  `update_by` BIGINT COMMENT '更新人ID',
+  `update_by` varchar(32) DEFAULT NULL COMMENT '更新人',
   `update_time` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='节点与角色关联表（多对多）';
 ```

--- a/doc/taskManager.md
+++ b/doc/taskManager.md
@@ -1,7 +1,7 @@
 # 任务管理模块（Spec v1.2）
 
 运行环境：MySQL 8+；不使用外键；所有删除均为逻辑删除 del\_flag。
-公共审计字段：create\_by / create\_time / update\_by / update\_time（BIGINT / DATETIME）。
+公共审计字段：create\_by / create\_time / update\_by / update\_time（VARCHAR(32) / DATETIME）。
 身份与权限：依赖 sys\_user / sys\_role / sys\_user\_role。
 关键约定：模板连边用模板节点ID；tc\_task\_node\_inst 包含 handler\_role\_ids（JSON 数组）。
 

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeInfoDto.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeInfoDto.java
@@ -28,14 +28,14 @@ public class NodeInfoDto {
     private List<NodeActionDto> actions;
 
     /** 创建人ID */
-    private Long creatorId;
+    private String creatorId;
     /** 创建人名称 */
     private String creatorName;
     /** 创建时间 */
     private LocalDateTime createTime;
 
     /** 更新人ID */
-    private Long updaterId;
+    private String updaterId;
     /** 更新人名称 */
     private String updaterName;
     /** 更新时间 */

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/entity/TcBaseEntity.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/entity/TcBaseEntity.java
@@ -19,11 +19,11 @@ public class TcBaseEntity {
     @TableLogic(value = "0", delval = "1")
     private Integer delFlag; // 0=未删, 1=已删
 
-    private Long createBy;
+    private String createBy;
 
     private LocalDateTime createTime;
 
-    private Long updateBy;
+    private String updateBy;
 
     private LocalDateTime updateTime;
 }

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcNodeServiceImpl.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcNodeServiceImpl.java
@@ -111,14 +111,14 @@ public class TcNodeServiceImpl implements TcNodeService {
             }
             // creator
             dto.setCreatorId(node.getCreateBy());
-            SysUser user = sysUserMapper.selectById(String.valueOf(node.getCreateBy()));
+            SysUser user = sysUserMapper.selectById(node.getCreateBy());
             if (user != null) {
                 dto.setCreatorName(user.getRealname());
             }
             dto.setCreateTime(node.getCreateTime());
             // updater
             dto.setUpdaterId(node.getUpdateBy());
-            SysUser upUser = sysUserMapper.selectById(String.valueOf(node.getUpdateBy()));
+            SysUser upUser = sysUserMapper.selectById(node.getUpdateBy());
             if (upUser != null) {
                 dto.setUpdaterName(upUser.getRealname());
             }
@@ -142,8 +142,8 @@ public class TcNodeServiceImpl implements TcNodeService {
         BeanUtil.copyProperties(dto, node);
         node.setDelFlag(0);
         if (loginUser != null) {
-            node.setCreateBy(Long.valueOf(loginUser.getId()));
-            node.setUpdateBy(Long.valueOf(loginUser.getId()));
+            node.setCreateBy(loginUser.getId());
+            node.setUpdateBy(loginUser.getId());
         }
         if (dto.getActions() != null) {
             node.setActions(JSON.toJSONString(dto.getActions()));
@@ -157,8 +157,8 @@ public class TcNodeServiceImpl implements TcNodeService {
                 rel.setRoleId(roleDto.getRoleId());
                 rel.setDelFlag(0);
                 if (loginUser != null) {
-                    rel.setCreateBy(Long.valueOf(loginUser.getId()));
-                    rel.setUpdateBy(Long.valueOf(loginUser.getId()));
+                    rel.setCreateBy(loginUser.getId());
+                    rel.setUpdateBy(loginUser.getId());
                 }
                 nodeRoleRelMapper.insert(rel);
             }
@@ -175,7 +175,7 @@ public class TcNodeServiceImpl implements TcNodeService {
         BeanUtil.copyProperties(dto, node);
         node.setId(id);
         if (loginUser != null) {
-            node.setUpdateBy(Long.valueOf(loginUser.getId()));
+            node.setUpdateBy(loginUser.getId());
         }
         if (dto.getActions() != null) {
             node.setActions(JSON.toJSONString(dto.getActions()));
@@ -196,8 +196,8 @@ public class TcNodeServiceImpl implements TcNodeService {
                     rel.setRoleId(roleDto.getRoleId());
                     rel.setDelFlag(0);
                     if (loginUser != null) {
-                        rel.setCreateBy(Long.valueOf(loginUser.getId()));
-                        rel.setUpdateBy(Long.valueOf(loginUser.getId()));
+                        rel.setCreateBy(loginUser.getId());
+                        rel.setUpdateBy(loginUser.getId());
                     }
                     nodeRoleRelMapper.insert(rel);
                 }
@@ -247,12 +247,12 @@ public class TcNodeServiceImpl implements TcNodeService {
             dto.setActions(actions);
         }
         dto.setCreatorId(node.getCreateBy());
-        SysUser creator = sysUserMapper.selectById(String.valueOf(node.getCreateBy()));
+        SysUser creator = sysUserMapper.selectById(node.getCreateBy());
         if (creator != null) {
             dto.setCreatorName(creator.getRealname());
         }
         dto.setUpdaterId(node.getUpdateBy());
-        SysUser upUser = sysUserMapper.selectById(String.valueOf(node.getUpdateBy()));
+        SysUser upUser = sysUserMapper.selectById(node.getUpdateBy());
         if (upUser != null) {
             dto.setUpdaterName(upUser.getRealname());
         }


### PR DESCRIPTION
## Summary
- use `varchar(32)` for `create_by`/`update_by` in task center tables
- track creator and updater as strings in task-center entities and services
- document updated audit field types

## Testing
- `mvn -q -e -pl system/biz -am test` *(failed: Non-resolvable parent POM)*
- `mvn -q -e -pl system/biz -am -o test` *(failed: artifact not downloaded in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a32be1e88330a6bb4d89f3aa486b