### PR TITLE
feat: store usernames for node auditing

### DIFF
--- a/doc/taskManager.md
+++ b/doc/taskManager.md
@@ -307,14 +307,14 @@ FROM tc_task t
 LEFT JOIN tc_todo_template tt ON tt.template_id = t.template_id
 LEFT JOIN curN_subquery curN ON curN.task_id = t.id
 WHERE_CONDITIONS
-  AND t.create_by = :userId
+  AND t.create_by = :userName
 ORDER BY t.create_time DESC
 LIMIT :offset, :pageSize;
 
 SELECT COUNT(1)
 FROM tc_task t
 WHERE_CONDITIONS
-  AND t.create_by = :userId;
+  AND t.create_by = :userName;
 
 ```
 **C) tab = todo（我的待办）**
@@ -600,7 +600,7 @@ Resp：任务主信息 + 当前激活节点ID集合（可选）
 
 列表（四个 Tab）
 
-* 发起的：`GET /task/list/startedByMe?userId&page&pageSize`
+* 发起的：`GET /task/list/startedByMe?userName&page&pageSize`
 * 待办： `GET /task/list/todo?userId&page&pageSize`
 * 参与： `GET /task/list/participated?userId&page&pageSize`
 * 已处理：`GET /task/list/handledByMyGroup?userId&page&pageSize`

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskManagerMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskManagerMapper.xml
@@ -41,7 +41,7 @@
             WHERE
             <include refid="whereCommon"/>
             <if test="query.tab == 'startedByMe'">
-                AND t.create_by = #{query.userId}
+                AND t.create_by = #{query.userName}
             </if>
             <if test="query.tab == 'todo'">
                 AND wi.del_flag = 0 AND wi.assignee_id = #{query.userId} AND wi.phase_status = 1
@@ -76,7 +76,7 @@
         WHERE
         <include refid="whereCommon"/>
         <if test="query.tab == 'startedByMe'">
-            AND t.create_by = #{query.userId}
+            AND t.create_by = #{query.userName}
         </if>
         <if test="query.tab == 'todo'">
             AND wi.del_flag = 0 AND wi.assignee_id = #{query.userId} AND wi.phase_status = 1

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/TaskManagerListQuery.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/TaskManagerListQuery.java
@@ -35,6 +35,8 @@ public class TaskManagerListQuery implements Serializable {
     private Integer pageSize;
     /** 当前登录用户ID */
     private String userId;
+    /** 当前登录用户名 */
+    private String userName;
     /** 偏移量，内部计算 */
     private Integer offset;
 }


### PR DESCRIPTION
## Summary
- pull logged-in user ID from thread-local storage in task manager service
- save creator and updater usernames for node info and role relations
- filter task manager queries by creator username and document username-based filtering

## Testing
- `mvn -q -pl system -am package -DskipTests` *(fails: Network is unreachable for aliyun repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d068bcdc83308d03e7f8c317d102