### PR TITLE
feat: add task cancel endpoint

### DIFF
--- a/common/src/main/java/com/zjlab/dataservice/common/constant/enums/ResultCode.java
+++ b/common/src/main/java/com/zjlab/dataservice/common/constant/enums/ResultCode.java
@@ -75,6 +75,7 @@ public enum ResultCode {
     TASK_IS_NOT_EXISTS(200002, "待办任务不存在"),
     INSTANCE_IS_EXISTS(200003, "实例已经存在"),
     INSTANCE_IS_NOT_EXISTS(200004, "实例对象不存在"),
+    TASK_CANNOT_CANCEL(200005, "已有节点完成，不能取消"),
 
 
     ;

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcTaskManagerController.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcTaskManagerController.java
@@ -9,7 +9,9 @@ import com.zjlab.dataservice.modules.tc.service.TcTaskManagerService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
@@ -34,5 +36,13 @@ public class TcTaskManagerController {
     @ApiOperation(value="任务列表", notes="分页查询任务列表")
     public Result<PageResult<TaskManagerListItemVO>> list(@Valid TaskManagerListQuery query) {
         return Result.ok(taskManagerService.listTasks(query));
+    }
+
+    @PostMapping("/cancel")
+    @ApiOperationSupport(order = 2)
+    @ApiOperation(value="取消任务", notes="取消指定任务")
+    public Result<Void> cancel(@RequestParam Long taskId) {
+        taskManagerService.cancelTask(taskId);
+        return Result.ok();
     }
 }

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/TcTaskManagerMapper.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/TcTaskManagerMapper.java
@@ -17,4 +17,19 @@ public interface TcTaskManagerMapper {
     Long countTaskList(@Param("query") TaskManagerListQuery query);
     /** 查询当前节点 */
     List<CurrentNodeRow> selectCurrentNodes(@Param("taskIds") List<Long> taskIds);
+
+    /** 查询任务状态 */
+    Integer selectTaskStatus(@Param("taskId") Long taskId);
+
+    /** 已完成节点数量 */
+    Long countDoneNodeInst(@Param("taskId") Long taskId);
+
+    /** 更新任务为取消 */
+    int updateTaskCancel(@Param("taskId") Long taskId, @Param("userName") String userName);
+
+    /** 取消节点实例 */
+    int updateNodeInstCancel(@Param("taskId") Long taskId, @Param("userName") String userName);
+
+    /** 取消工作项 */
+    int updateWorkItemCancel(@Param("taskId") Long taskId, @Param("userName") String userName);
 }

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskManagerMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskManagerMapper.xml
@@ -106,4 +106,37 @@
         ORDER BY ni.task_id, ni.order_no, ni.id
     </select>
 
+    <select id="selectTaskStatus" resultType="int">
+        SELECT status FROM tc_task WHERE id = #{taskId} AND del_flag = 0 FOR UPDATE
+    </select>
+
+    <select id="countDoneNodeInst" resultType="long">
+        SELECT COUNT(*) FROM tc_task_node_inst
+        WHERE task_id = #{taskId} AND del_flag = 0 AND status = 2 FOR UPDATE
+    </select>
+
+    <update id="updateTaskCancel">
+        UPDATE tc_task
+        SET status = 3,
+            update_by = #{userName},
+            update_time = NOW()
+        WHERE id = #{taskId} AND del_flag = 0
+    </update>
+
+    <update id="updateNodeInstCancel">
+        UPDATE tc_task_node_inst
+        SET status = 3,
+            update_by = #{userName},
+            update_time = NOW()
+        WHERE task_id = #{taskId} AND del_flag = 0 AND status IN (0,1)
+    </update>
+
+    <update id="updateWorkItemCancel">
+        UPDATE tc_task_work_item
+        SET phase_status = 3,
+            update_by = #{userName},
+            update_time = NOW()
+        WHERE task_id = #{taskId} AND del_flag = 0 AND phase_status IN (0,1)
+    </update>
+
 </mapper>

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/TcTaskManagerService.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/TcTaskManagerService.java
@@ -12,4 +12,10 @@ public interface TcTaskManagerService {
      * 分页查询任务列表
      */
     PageResult<TaskManagerListItemVO> listTasks(TaskManagerListQuery query);
+
+    /**
+     * 取消任务
+     * @param taskId 任务ID
+     */
+    void cancelTask(Long taskId);
 }


### PR DESCRIPTION
## Summary
- add task cancellation API under task manager controller
- implement cancellation service with mapper and error code
- support SQL updates for task, node instances, and work items

## Testing
- `mvn -q -pl system/biz -am test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f89926f48330be5b2b24d9f68c0a