### PR TITLE
Enforce user ID checks and admin-only task view

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/system/service/ISysUserService.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/system/service/ISysUserService.java
@@ -313,15 +313,22 @@ public interface ISysUserService extends IService<SysUser> {
      * @param userIdList
      * @return List<String>
      */
-	List<String> userIdToUsername(Collection<String> userIdList);
+        List<String> userIdToUsername(Collection<String> userIdList);
 
 
-	/**
-	 * 获取用户信息 字段信息是加密后的 【加密用户信息】
-	 * @param username
-	 * @return
-	 */
-	LoginUser getEncodeUserInfo(String username);
+        /**
+         * 获取用户信息 字段信息是加密后的 【加密用户信息】
+         * @param username
+         * @return
+         */
+        LoginUser getEncodeUserInfo(String username);
+
+        /**
+         * 判断用户是否为管理员
+         * @param userId 用户ID
+         * @return boolean 是否管理员
+         */
+        boolean isAdmin(String userId);
 
     /**
      * 用户离职

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/system/service/impl/SysUserServiceImpl.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/system/service/impl/SysUserServiceImpl.java
@@ -1319,4 +1319,21 @@ public class SysUserServiceImpl extends ServiceImpl<SysUserMapper, SysUser> impl
             }
         }
     }
+
+    @Override
+    public boolean isAdmin(String userId) {
+        if (oConvertUtils.isEmpty(userId)) {
+            return false;
+        }
+        SysUser user = userMapper.selectById(userId);
+        if (user == null) {
+            return false;
+        }
+        List<String> roleCodes = sysUserRoleMapper.getRoleByUserName(user.getUsername());
+        if (roleCodes != null && roleCodes.contains("admin")) {
+            return true;
+        }
+        List<String> roleIds = sysUserRoleMapper.getRoleIdByUserName(user.getUsername());
+        return roleIds != null && roleIds.contains("f6817f48af4fb3af11b9e8bf182f618b");
+    }
 }

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcTaskManagerController.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcTaskManagerController.java
@@ -19,8 +19,6 @@ import javax.validation.Valid;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
-import javax.annotation.Resource;
-
 /** 任务列表接口 */
 @RestController
 @RequestMapping("/tc/taskManager")

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcNodeServiceImpl.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcNodeServiceImpl.java
@@ -139,10 +139,9 @@ public class TcNodeServiceImpl implements TcNodeService {
     @Transactional(rollbackFor = RuntimeException.class)
     public Long createNode(NodeInfoDto dto) {
         String userId = UserThreadLocal.getUserId();
-        //todo 后续放开
-//        if (userId == null) {
-//            throw new BaseException(ResultCode.USERID_IS_NULL);
-//        }
+        if (userId == null) {
+            throw new BaseException(ResultCode.USERID_IS_NULL);
+        }
         SysUser loginUser = sysUserMapper.selectById(userId);
         NodeInfo node = new NodeInfo();
         BeanUtil.copyProperties(dto, node);
@@ -177,10 +176,9 @@ public class TcNodeServiceImpl implements TcNodeService {
     @Transactional(rollbackFor = RuntimeException.class)
     public void updateNode(Long id, NodeInfoDto dto) {
         String userId = UserThreadLocal.getUserId();
-        //todo 后续放开
-//        if (userId == null) {
-//            throw new BaseException(ResultCode.USERID_IS_NULL);
-//        }
+        if (userId == null) {
+            throw new BaseException(ResultCode.USERID_IS_NULL);
+        }
         SysUser loginUser = sysUserMapper.selectById(userId);
         NodeInfo node = new NodeInfo();
         BeanUtil.copyProperties(dto, node);


### PR DESCRIPTION
## Summary
- require user ID from thread-local before listing or cancelling tasks
- restrict "all" task tab to administrators and force admins to that view
- validate user ID in node create and update operations

## Testing
- `mvn -q -pl system/biz test` *(fails: Non-resolvable parent POM, network is unreachable and 'parent.relativePath' points at no local POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a8000bd6e88330883df62a922cd6c0