### PR TITLE
refactor: remove generic exception handling in TcNodeController

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcNodeController.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcNodeController.java
@@ -28,11 +28,7 @@ public class TcNodeController {
     @ApiOperationSupport(order = 1)
     @ApiOperation(value = "获取节点统计数据")
     public Result<NodeStatsVo> stats() {
-        try {
-            return Result.ok(tcNodeService.getStats());
-        } catch (Exception e) {
-            return Result.error("获取节点统计数据失败: " + e.getMessage());
-        }
+        return Result.ok(tcNodeService.getStats());
     }
 
     /**
@@ -42,11 +38,7 @@ public class TcNodeController {
     @ApiOperationSupport(order = 2)
     @ApiOperation(value = "查询节点列表")
     public Result<PageResult<NodeInfoDto>> list(NodeQueryDto queryDto) {
-        try {
-            return Result.ok(tcNodeService.listNodes(queryDto));
-        } catch (Exception e) {
-            return Result.error("查询节点列表失败: " + e.getMessage());
-        }
+        return Result.ok(tcNodeService.listNodes(queryDto));
     }
 
     /**
@@ -56,11 +48,7 @@ public class TcNodeController {
     @ApiOperationSupport(order = 3)
     @ApiOperation(value = "新建节点")
     public Result<Long> create(@RequestBody NodeInfoDto dto) {
-        try {
-            return Result.ok(tcNodeService.createNode(dto));
-        } catch (Exception e) {
-            return Result.error("新建节点失败: " + e.getMessage());
-        }
+        return Result.ok(tcNodeService.createNode(dto));
     }
 
     /**
@@ -70,12 +58,8 @@ public class TcNodeController {
     @ApiOperationSupport(order = 4)
     @ApiOperation(value = "编辑节点")
     public Result<Void> update(@PathVariable Long id, @RequestBody NodeInfoDto dto) {
-        try {
-            tcNodeService.updateNode(id, dto);
-            return Result.ok();
-        } catch (Exception e) {
-            return Result.error("编辑节点失败: " + e.getMessage());
-        }
+        tcNodeService.updateNode(id, dto);
+        return Result.ok();
     }
 
     /**
@@ -85,12 +69,8 @@ public class TcNodeController {
     @ApiOperationSupport(order = 5)
     @ApiOperation(value = "更新节点状态")
     public Result<Void> updateStatus(@PathVariable Long id, @RequestParam Integer status) {
-        try {
-            tcNodeService.updateStatus(id, status);
-            return Result.ok();
-        } catch (Exception e) {
-            return Result.error("更新节点状态失败: " + e.getMessage());
-        }
+        tcNodeService.updateStatus(id, status);
+        return Result.ok();
     }
 
     /**
@@ -100,12 +80,8 @@ public class TcNodeController {
     @ApiOperationSupport(order = 6)
     @ApiOperation(value = "删除节点")
     public Result<Void> delete(@PathVariable Long id) {
-        try {
-            tcNodeService.deleteNode(id);
-            return Result.ok();
-        } catch (Exception e) {
-            return Result.error("删除节点失败: " + e.getMessage());
-        }
+        tcNodeService.deleteNode(id);
+        return Result.ok();
     }
 
     /**
@@ -115,10 +91,6 @@ public class TcNodeController {
     @ApiOperationSupport(order = 7)
     @ApiOperation(value = "获取节点详情")
     public Result<NodeInfoDto> detail(@PathVariable Long id) {
-        try {
-            return Result.ok(tcNodeService.getDetail(id));
-        } catch (Exception e) {
-            return Result.error("获取节点详情失败: " + e.getMessage());
-        }
+        return Result.ok(tcNodeService.getDetail(id));
     }
 }


### PR DESCRIPTION
## Summary
- simplify TcNodeController by removing broad Exception try/catch blocks

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for org.jeecgframework.boot:jeecg-boot-parent:3.5.1, Unknown host maven.aliyun.com)*

------
https://chatgpt.com/codex/tasks/task_e_68a8325074d083308f2e51f66ca07a6a