### PR TITLE
Add workflow node decision action handling

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcTaskManagerController.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcTaskManagerController.java
@@ -6,6 +6,7 @@ import com.zjlab.dataservice.common.api.vo.Result;
 import com.zjlab.dataservice.modules.tc.model.dto.TaskManagerCreateDto;
 import com.zjlab.dataservice.modules.tc.model.dto.TaskManagerEditDto;
 import com.zjlab.dataservice.modules.tc.model.dto.TaskManagerListQuery;
+import com.zjlab.dataservice.modules.tc.model.dto.NodeActionSubmitDto;
 import com.zjlab.dataservice.modules.tc.model.vo.TaskManagerListItemVO;
 import com.zjlab.dataservice.modules.tc.model.vo.RemoteCmdExportVO;
 import com.zjlab.dataservice.modules.tc.model.vo.OrbitPlanExportVO;
@@ -106,5 +107,13 @@ public class TcTaskManagerController {
     public Result<List<TemplateNodeFlowVO>> nodeFlows(@RequestParam String templateId) {
         List<TemplateNodeFlowVO> flows = taskManagerService.listNodeFlows(templateId);
         return Result.ok(flows);
+    }
+
+    @PostMapping("/node/submit")
+    @ApiOperationSupport(order = 7)
+    @ApiOperation(value = "提交节点操作", notes = "节点办理操作提交")
+    public Result<Void> submitNodeAction(@RequestBody @Valid NodeActionSubmitDto dto) {
+        taskManagerService.submitAction(dto);
+        return Result.ok();
     }
 }

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/TaskNodeActionRecordMapper.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/TaskNodeActionRecordMapper.java
@@ -1,0 +1,11 @@
+package com.zjlab.dataservice.modules.tc.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.zjlab.dataservice.modules.tc.model.entity.TaskNodeActionRecord;
+
+/**
+ * 节点操作记录 Mapper
+ */
+public interface TaskNodeActionRecordMapper extends BaseMapper<TaskNodeActionRecord> {
+}
+

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/TcTaskManagerMapper.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/TcTaskManagerMapper.java
@@ -41,6 +41,9 @@ public interface TcTaskManagerMapper {
     /** 激活节点实例 */
     int activateNodeInst(@Param("nodeInstId") Long nodeInstId,
                          @Param("userId") String userId);
+    /** 完成节点实例 */
+    int completeNodeInst(@Param("nodeInstId") Long nodeInstId,
+                         @Param("userId") String userId);
     /** 查询列表 */
     List<TaskManagerListItemVO> selectTaskList(@Param("query") TaskManagerListQuery query);
     /** 统计总数 */
@@ -59,9 +62,6 @@ public interface TcTaskManagerMapper {
 
     /** 取消节点实例 */
     int updateNodeInstCancel(@Param("taskId") Long taskId, @Param("userId") String userId);
-
-    /** 取消工作项 */
-    int updateWorkItemCancel(@Param("taskId") Long taskId, @Param("userId") String userId);
 
     /** 查询任务编辑信息 */
     TaskManagerEditInfo selectTaskForEdit(@Param("taskId") Long taskId);
@@ -102,18 +102,31 @@ public interface TcTaskManagerMapper {
     /** 根据角色ID集合查询用户ID */
     List<String> selectUserIdsByRoleIds(@Param("roleIds") List<String> roleIds);
 
-    /** 插入工作项 */
-    int insertWorkItem(@Param("taskId") Long taskId,
-                       @Param("nodeInstId") Long nodeInstId,
-                       @Param("assigneeId") String assigneeId,
-                       @Param("phaseStatus") int phaseStatus,
-                       @Param("userId") String userId);
-
-    /** 删除节点的工作项 */
-    int deleteWorkItemsByNodeInst(@Param("nodeInstId") Long nodeInstId,
-                                  @Param("userId") String userId);
-
     /** 根据模板ID查询节点流 */
     List<TemplateNodeFlowVO> selectTemplateNodeFlows(@Param("templateId") String templateId);
+
+    /** 查询节点实例的后继ID JSON */
+    String selectNextNodeIds(@Param("nodeInstId") Long nodeInstId);
+
+    /** 增加节点实例的到达前驱计数 */
+    int increaseArrivedCount(@Param("nodeInstId") Long nodeInstId, @Param("userId") String userId);
+
+    /** 查询节点实例的办理角色ID集合JSON */
+    String selectHandlerRoleIds(@Param("nodeInstId") Long nodeInstId);
+
+    /** 统计任务进行中节点数量 */
+    Long countOngoingNodeInst(@Param("taskId") Long taskId);
+
+    /** 更新任务状态为已完成 */
+    int updateTaskComplete(@Param("taskId") Long taskId, @Param("userId") String userId);
+
+    /** 更新任务状态为异常结束 */
+    int updateTaskAbort(@Param("taskId") Long taskId, @Param("userId") String userId);
+
+    /** 异常结束节点实例 */
+    int updateNodeInstAbort(@Param("taskId") Long taskId, @Param("userId") String userId);
+
+    /** 查询节点实例状态 */
+    Integer selectNodeInstStatus(@Param("nodeInstId") Long nodeInstId);
 
 }

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/TcTaskWorkItemMapper.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/TcTaskWorkItemMapper.java
@@ -1,0 +1,38 @@
+package com.zjlab.dataservice.modules.tc.mapper;
+
+import org.apache.ibatis.annotations.Param;
+
+/**
+ * 任务工作项相关操作
+ */
+public interface TcTaskWorkItemMapper {
+    /** 插入工作项 */
+    int insertWorkItem(@Param("taskId") Long taskId,
+                       @Param("nodeInstId") Long nodeInstId,
+                       @Param("assigneeId") String assigneeId,
+                       @Param("phaseStatus") int phaseStatus,
+                       @Param("userId") String userId);
+
+    /** 删除节点的工作项 */
+    int deleteWorkItemsByNodeInst(@Param("nodeInstId") Long nodeInstId,
+                                  @Param("userId") String userId);
+
+    /** 取消任务的工作项 */
+    int updateWorkItemCancel(@Param("taskId") Long taskId,
+                             @Param("userId") String userId);
+
+    /** 更新当前用户工作项为已处理 */
+    int updateMyWorkItem(@Param("taskId") Long taskId,
+                         @Param("nodeInstId") Long nodeInstId,
+                         @Param("userId") String userId);
+
+    /** 更新其他用户工作项为他人已完成失效 */
+    int updateOtherWorkItem(@Param("taskId") Long taskId,
+                             @Param("nodeInstId") Long nodeInstId,
+                             @Param("userId") String userId);
+
+    /** 异常结束任务工作项 */
+    int updateWorkItemAbort(@Param("taskId") Long taskId,
+                            @Param("userId") String userId);
+}
+

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskManagerMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskManagerMapper.xml
@@ -76,7 +76,18 @@
             update_by = #{userId},
             update_time = NOW()
         WHERE id = #{nodeInstId} AND status = 0 AND del_flag = 0
+          AND arrived_count &gt;= JSON_LENGTH(prev_node_ids)
     </update>
+    <update id="completeNodeInst">
+        UPDATE tc_task_node_inst
+        SET status = 2,
+            completed_at = NOW(),
+            completed_by = #{userId},
+            update_by = #{userId},
+            update_time = NOW()
+        WHERE id = #{nodeInstId} AND status = 1 AND del_flag = 0
+    </update>
+
 
     <select id="selectTaskList" resultType="com.zjlab.dataservice.modules.tc.model.vo.TaskManagerListItemVO">
         SELECT
@@ -174,14 +185,6 @@
         WHERE task_id = #{taskId} AND del_flag = 0 AND status IN (0,1)
     </update>
 
-    <update id="updateWorkItemCancel">
-        UPDATE tc_task_work_item
-        SET phase_status = 3,
-            update_by = #{userId},
-            update_time = NOW()
-        WHERE task_id = #{taskId} AND del_flag = 0 AND phase_status IN (0,1)
-    </update>
-
     <select id="selectTaskForEdit" resultType="com.zjlab.dataservice.modules.tc.model.dto.TaskManagerEditInfo">
         SELECT status, create_by AS createBy, template_id AS templateId, result_display_needed AS resultDisplayNeeded
         FROM tc_task
@@ -263,23 +266,57 @@
         </foreach>
     </select>
 
-    <insert id="insertWorkItem">
-        INSERT INTO tc_task_work_item(
-            task_id, node_inst_id, assignee_id, phase_status,
-            create_by, create_time, update_by, update_time
-        ) VALUES (
-            #{taskId}, #{nodeInstId}, #{assigneeId}, #{phaseStatus},
-            #{userId}, NOW(), #{userId}, NOW()
-        )
-    </insert>
+    <select id="selectNextNodeIds" resultType="string">
+        SELECT next_node_ids FROM tc_task_node_inst
+        WHERE id = #{nodeInstId} AND del_flag = 0
+    </select>
 
-    <update id="deleteWorkItemsByNodeInst">
-        UPDATE tc_task_work_item
-        SET del_flag = 1,
+    <update id="increaseArrivedCount">
+        UPDATE tc_task_node_inst
+        SET arrived_count = arrived_count + 1,
             update_by = #{userId},
             update_time = NOW()
-        WHERE node_inst_id = #{nodeInstId} AND del_flag = 0
+        WHERE id = #{nodeInstId} AND del_flag = 0
     </update>
+
+    <select id="selectHandlerRoleIds" resultType="string">
+        SELECT handler_role_ids FROM tc_task_node_inst
+        WHERE id = #{nodeInstId} AND del_flag = 0
+    </select>
+
+    <select id="countOngoingNodeInst" resultType="long">
+        SELECT COUNT(*) FROM tc_task_node_inst
+        WHERE task_id = #{taskId} AND del_flag = 0 AND status IN (0,1)
+    </select>
+
+    <update id="updateTaskComplete">
+        UPDATE tc_task
+        SET status = 1,
+            update_by = #{userId},
+            update_time = NOW()
+        WHERE id = #{taskId} AND del_flag = 0
+    </update>
+
+    <update id="updateTaskAbort">
+        UPDATE tc_task
+        SET status = 2,
+            update_by = #{userId},
+            update_time = NOW()
+        WHERE id = #{taskId} AND del_flag = 0
+    </update>
+
+    <update id="updateNodeInstAbort">
+        UPDATE tc_task_node_inst
+        SET status = 4,
+            update_by = #{userId},
+            update_time = NOW()
+        WHERE task_id = #{taskId} AND del_flag = 0 AND status IN (0,1)
+    </update>
+
+    <select id="selectNodeInstStatus" resultType="int">
+        SELECT status FROM tc_task_node_inst
+        WHERE id = #{nodeInstId} AND del_flag = 0
+    </select>
 
     <select id="selectTemplateNodeFlows" resultType="com.zjlab.dataservice.modules.tc.model.vo.TemplateNodeFlowVO">
         SELECT

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskWorkItemMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskWorkItemMapper.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.zjlab.dataservice.modules.tc.mapper.TcTaskWorkItemMapper">
+
+    <insert id="insertWorkItem">
+        INSERT INTO tc_task_work_item(
+            task_id, node_inst_id, assignee_id, phase_status,
+            create_by, create_time, update_by, update_time
+        ) VALUES (
+            #{taskId}, #{nodeInstId}, #{assigneeId}, #{phaseStatus},
+            #{userId}, NOW(), #{userId}, NOW()
+        )
+    </insert>
+
+    <update id="deleteWorkItemsByNodeInst">
+        UPDATE tc_task_work_item
+        SET del_flag = 1,
+            update_by = #{userId},
+            update_time = NOW()
+        WHERE node_inst_id = #{nodeInstId} AND del_flag = 0
+    </update>
+
+    <update id="updateWorkItemCancel">
+        UPDATE tc_task_work_item
+        SET phase_status = 3,
+            update_by = #{userId},
+            update_time = NOW()
+        WHERE task_id = #{taskId} AND del_flag = 0 AND phase_status IN (0,1)
+    </update>
+
+    <update id="updateMyWorkItem">
+        UPDATE tc_task_work_item
+        SET phase_status = 2,
+            update_by = #{userId},
+            update_time = NOW()
+        WHERE task_id = #{taskId} AND node_inst_id = #{nodeInstId} AND assignee_id = #{userId} AND del_flag = 0
+    </update>
+
+    <update id="updateOtherWorkItem">
+        UPDATE tc_task_work_item
+        SET phase_status = 4,
+            update_by = #{userId},
+            update_time = NOW()
+        WHERE task_id = #{taskId} AND node_inst_id = #{nodeInstId} AND assignee_id &lt;&gt; #{userId} AND del_flag = 0 AND phase_status IN (0,1)
+    </update>
+
+    <update id="updateWorkItemAbort">
+        UPDATE tc_task_work_item
+        SET phase_status = 5,
+            update_by = #{userId},
+            update_time = NOW()
+        WHERE task_id = #{taskId} AND del_flag = 0 AND phase_status IN (0,1)
+    </update>
+
+</mapper>

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeActionSubmitDto.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeActionSubmitDto.java
@@ -1,0 +1,23 @@
+package com.zjlab.dataservice.modules.tc.model.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * 节点操作提交参数
+ */
+@Data
+public class NodeActionSubmitDto {
+    /** 任务ID */
+    @NotNull
+    private Long taskId;
+    /** 节点实例ID */
+    @NotNull
+    private Long nodeInstId;
+    /** 操作类型(0上传,1选择计划,2决策,3文本等) */
+    @NotNull
+    private Integer actionType;
+    /** 提交内容JSON */
+    private String actionPayload;
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/entity/TaskNodeActionRecord.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/entity/TaskNodeActionRecord.java
@@ -1,0 +1,22 @@
+package com.zjlab.dataservice.modules.tc.model.entity;
+
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+/**
+ * 节点操作记录
+ */
+@Data
+@TableName("tc_task_node_action_record")
+public class TaskNodeActionRecord extends TcBaseEntity {
+    private static final long serialVersionUID = 1L;
+
+    /** 任务ID */
+    private Long taskId;
+    /** 节点实例ID */
+    private Long nodeInstId;
+    /** 操作类型(0上传,1选择计划,2决策,3文本等) */
+    private Integer actionType;
+    /** 提交内容JSON */
+    private String actionPayload;
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/TcTaskManagerService.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/TcTaskManagerService.java
@@ -4,6 +4,7 @@ import com.zjlab.dataservice.common.api.page.PageResult;
 import com.zjlab.dataservice.modules.tc.model.dto.TaskManagerCreateDto;
 import com.zjlab.dataservice.modules.tc.model.dto.TaskManagerEditDto;
 import com.zjlab.dataservice.modules.tc.model.dto.TaskManagerListQuery;
+import com.zjlab.dataservice.modules.tc.model.dto.NodeActionSubmitDto;
 import com.zjlab.dataservice.modules.tc.model.vo.TaskManagerListItemVO;
 import com.zjlab.dataservice.modules.tc.model.vo.TemplateNodeFlowVO;
 
@@ -50,4 +51,11 @@ public interface TcTaskManagerService {
      * @return 节点流列表
      */
     List<TemplateNodeFlowVO> listNodeFlows(String templateId);
+
+    /**
+     * 提交节点操作
+     *
+     * @param dto 节点操作参数
+     */
+    void submitAction(NodeActionSubmitDto dto);
 }


### PR DESCRIPTION
## Summary
- consolidate node action submission into task manager service with stepwise comments
- call task manager service directly from controller and drop separate node action service
- add detailed inline comments in task and node service implementations
- move work item operations into dedicated `TcTaskWorkItemMapper`

## Testing
- `mvn -q -e -DskipTests package` *(fails: Non-resolvable parent POM for org.jeecgframework.boot:jeecg-boot-parent:3.5.1; Unknown host maven.aliyun.com)*

------
https://chatgpt.com/codex/tasks/task_e_68abe0d4e9348330bea7f6d14b41b25d