### PR TITLE
refactor: split node inst mapper

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/TcTaskManagerMapper.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/TcTaskManagerMapper.java
@@ -1,6 +1,5 @@
 package com.zjlab.dataservice.modules.tc.mapper;
 
-import com.zjlab.dataservice.modules.tc.model.dto.CurrentNodeRow;
 import com.zjlab.dataservice.modules.tc.model.dto.TaskManagerEditDto;
 import com.zjlab.dataservice.modules.tc.model.dto.TaskManagerEditInfo;
 import com.zjlab.dataservice.modules.tc.model.dto.TaskManagerListQuery;
@@ -23,45 +22,16 @@ public interface TcTaskManagerMapper {
     /** 查询模板属性 */
     String selectTemplateAttr(@Param("templateId") String templateId);
 
-    /** 插入节点实例 */
-    int insertNodeInst(@Param("taskId") Long taskId,
-                       @Param("templateId") String templateId,
-                       @Param("nodeId") Long nodeId,
-                       @Param("handlerRoleIds") String handlerRoleIds,
-                       @Param("orderNo") Integer orderNo,
-                       @Param("maxDuration") Integer maxDuration,
-                       @Param("userId") String userId);
-
-    /** 更新节点实例前后驱 */
-    int updateNodeInstPrevNext(@Param("nodeInstId") Long nodeInstId,
-                               @Param("prevNodeIds") String prevNodeIds,
-                               @Param("nextNodeIds") String nextNodeIds,
-                               @Param("userId") String userId);
-
-    /** 激活节点实例 */
-    int activateNodeInst(@Param("nodeInstId") Long nodeInstId,
-                         @Param("userId") String userId);
-    /** 完成节点实例 */
-    int completeNodeInst(@Param("nodeInstId") Long nodeInstId,
-                         @Param("userId") String userId);
     /** 查询列表 */
     List<TaskManagerListItemVO> selectTaskList(@Param("query") TaskManagerListQuery query);
     /** 统计总数 */
     Long countTaskList(@Param("query") TaskManagerListQuery query);
-    /** 查询当前节点 */
-    List<CurrentNodeRow> selectCurrentNodes(@Param("taskIds") List<Long> taskIds);
 
     /** 查询任务状态 */
     Integer selectTaskStatus(@Param("taskId") Long taskId);
 
-    /** 已完成节点数量 */
-    Long countDoneNodeInst(@Param("taskId") Long taskId);
-
     /** 更新任务为取消 */
     int updateTaskCancel(@Param("taskId") Long taskId, @Param("userId") String userId);
-
-    /** 取消节点实例 */
-    int updateNodeInstCancel(@Param("taskId") Long taskId, @Param("userId") String userId);
 
     /** 查询任务编辑信息 */
     TaskManagerEditInfo selectTaskForEdit(@Param("taskId") Long taskId);
@@ -69,35 +39,8 @@ public interface TcTaskManagerMapper {
     /** 更新任务基本信息 */
     int updateTask(@Param("dto") TaskManagerEditDto dto, @Param("userId") String userId);
 
-    /** 查询末端节点实例ID */
-    List<Long> selectEndNodeInstIds(@Param("taskId") Long taskId);
-
-    /** 插入查看结果节点实例 */
-    int insertViewNodeInst(@Param("taskId") Long taskId,
-                           @Param("templateId") String templateId,
-                           @Param("nodeId") Long nodeId,
-                           @Param("prevNodeIds") String prevNodeIds,
-                           @Param("handlerRoleIds") String handlerRoleIds,
-                           @Param("userId") String userId);
-
     /** 查询最近插入ID */
     Long selectLastInsertId();
-
-    /** 末端节点追加指向 */
-    int appendViewNodeToEndNodes(@Param("nodeInstId") Long nodeInstId,
-                                 @Param("endInstIds") List<Long> endInstIds,
-                                 @Param("userId") String userId);
-
-    /** 查询查看结果节点实例ID */
-    Long selectViewNodeInstId(@Param("taskId") Long taskId, @Param("nodeId") Long nodeId);
-
-    /** 删除节点实例 */
-    int deleteNodeInst(@Param("nodeInstId") Long nodeInstId, @Param("userId") String userId);
-
-    /** 清理末端节点指向 */
-    int clearEndNodeNext(@Param("taskId") Long taskId,
-                         @Param("nodeInstId") Long nodeInstId,
-                         @Param("userId") String userId);
 
     /** 根据角色ID集合查询用户ID */
     List<String> selectUserIdsByRoleIds(@Param("roleIds") List<String> roleIds);
@@ -105,28 +48,10 @@ public interface TcTaskManagerMapper {
     /** 根据模板ID查询节点流 */
     List<TemplateNodeFlowVO> selectTemplateNodeFlows(@Param("templateId") String templateId);
 
-    /** 查询节点实例的后继ID JSON */
-    String selectNextNodeIds(@Param("nodeInstId") Long nodeInstId);
-
-    /** 增加节点实例的到达前驱计数 */
-    int increaseArrivedCount(@Param("nodeInstId") Long nodeInstId, @Param("userId") String userId);
-
-    /** 查询节点实例的办理角色ID集合JSON */
-    String selectHandlerRoleIds(@Param("nodeInstId") Long nodeInstId);
-
-    /** 统计任务进行中节点数量 */
-    Long countOngoingNodeInst(@Param("taskId") Long taskId);
-
     /** 更新任务状态为已完成 */
     int updateTaskComplete(@Param("taskId") Long taskId, @Param("userId") String userId);
 
     /** 更新任务状态为异常结束 */
     int updateTaskAbort(@Param("taskId") Long taskId, @Param("userId") String userId);
-
-    /** 异常结束节点实例 */
-    int updateNodeInstAbort(@Param("taskId") Long taskId, @Param("userId") String userId);
-
-    /** 查询节点实例状态 */
-    Integer selectNodeInstStatus(@Param("nodeInstId") Long nodeInstId);
 
 }

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/TcTaskNodeInstMapper.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/TcTaskNodeInstMapper.java
@@ -1,0 +1,72 @@
+package com.zjlab.dataservice.modules.tc.mapper;
+
+import com.zjlab.dataservice.modules.tc.model.dto.CurrentNodeRow;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+/**
+ * 节点实例相关 Mapper
+ */
+public interface TcTaskNodeInstMapper {
+    int insertNodeInst(@Param("taskId") Long taskId,
+                       @Param("templateId") String templateId,
+                       @Param("nodeId") Long nodeId,
+                       @Param("handlerRoleIds") String handlerRoleIds,
+                       @Param("orderNo") Integer orderNo,
+                       @Param("maxDuration") Integer maxDuration,
+                       @Param("userId") String userId);
+
+    int updateNodeInstPrevNext(@Param("nodeInstId") Long nodeInstId,
+                               @Param("prevNodeIds") String prevNodeIds,
+                               @Param("nextNodeIds") String nextNodeIds,
+                               @Param("userId") String userId);
+
+    int activateNodeInst(@Param("nodeInstId") Long nodeInstId,
+                         @Param("userId") String userId);
+
+    int completeNodeInst(@Param("nodeInstId") Long nodeInstId,
+                         @Param("userId") String userId);
+
+    List<CurrentNodeRow> selectCurrentNodes(@Param("taskIds") List<Long> taskIds);
+
+    Long countDoneNodeInst(@Param("taskId") Long taskId);
+
+    int updateNodeInstCancel(@Param("taskId") Long taskId, @Param("userId") String userId);
+
+    List<Long> selectEndNodeInstIds(@Param("taskId") Long taskId);
+
+    int insertViewNodeInst(@Param("taskId") Long taskId,
+                           @Param("templateId") String templateId,
+                           @Param("nodeId") Long nodeId,
+                           @Param("prevNodeIds") String prevNodeIds,
+                           @Param("handlerRoleIds") String handlerRoleIds,
+                           @Param("userId") String userId);
+
+    Long selectLastInsertId();
+
+    int appendViewNodeToEndNodes(@Param("nodeInstId") Long nodeInstId,
+                                 @Param("endInstIds") List<Long> endInstIds,
+                                 @Param("userId") String userId);
+
+    Long selectViewNodeInstId(@Param("taskId") Long taskId, @Param("nodeId") Long nodeId);
+
+    int deleteNodeInst(@Param("nodeInstId") Long nodeInstId, @Param("userId") String userId);
+
+    int clearEndNodeNext(@Param("taskId") Long taskId,
+                         @Param("nodeInstId") Long nodeInstId,
+                         @Param("userId") String userId);
+
+    String selectNextNodeIds(@Param("nodeInstId") Long nodeInstId);
+
+    int increaseArrivedCount(@Param("nodeInstId") Long nodeInstId, @Param("userId") String userId);
+
+    String selectHandlerRoleIds(@Param("nodeInstId") Long nodeInstId);
+
+    Long countOngoingNodeInst(@Param("taskId") Long taskId);
+
+    int updateNodeInstAbort(@Param("taskId") Long taskId, @Param("userId") String userId);
+
+    Integer selectNodeInstStatus(@Param("nodeInstId") Long nodeInstId);
+}
+

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskManagerMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskManagerMapper.xml
@@ -48,47 +48,6 @@
         WHERE template_id = #{templateId} AND del_flag = 0
     </select>
 
-    <insert id="insertNodeInst">
-        INSERT INTO tc_task_node_inst(
-            task_id, template_id, node_id, prev_node_ids, next_node_ids,
-            arrived_count, handler_role_ids, order_no, status, max_duration,
-            create_by, create_time, update_by, update_time
-        ) VALUES (
-            #{taskId}, #{templateId}, #{nodeId}, '[]', '[]',
-            0, #{handlerRoleIds}, #{orderNo}, 0, #{maxDuration},
-            #{userId}, NOW(), #{userId}, NOW()
-        )
-    </insert>
-
-    <update id="updateNodeInstPrevNext">
-        UPDATE tc_task_node_inst
-        SET prev_node_ids = #{prevNodeIds},
-            next_node_ids = #{nextNodeIds},
-            update_by = #{userId},
-            update_time = NOW()
-        WHERE id = #{nodeInstId} AND del_flag = 0
-    </update>
-
-    <update id="activateNodeInst">
-        UPDATE tc_task_node_inst
-        SET status = 1,
-            started_at = NOW(),
-            update_by = #{userId},
-            update_time = NOW()
-        WHERE id = #{nodeInstId} AND status = 0 AND del_flag = 0
-          AND arrived_count &gt;= JSON_LENGTH(prev_node_ids)
-    </update>
-    <update id="completeNodeInst">
-        UPDATE tc_task_node_inst
-        SET status = 2,
-            completed_at = NOW(),
-            completed_by = #{userId},
-            update_by = #{userId},
-            update_time = NOW()
-        WHERE id = #{nodeInstId} AND status = 1 AND del_flag = 0
-    </update>
-
-
     <select id="selectTaskList" resultType="com.zjlab.dataservice.modules.tc.model.vo.TaskManagerListItemVO">
         SELECT
         <include refid="selectFields"/>
@@ -144,29 +103,8 @@
         </if>
     </select>
 
-    <select id="selectCurrentNodes" resultType="com.zjlab.dataservice.modules.tc.model.dto.CurrentNodeRow">
-        SELECT
-            ni.task_id AS taskId,
-            ni.id AS nodeInstId,
-            ninfo.name AS nodeName,
-            ni.handler_role_ids AS handlerRoleIds
-        FROM tc_task_node_inst ni
-        JOIN tc_node_info ninfo ON ninfo.id = ni.node_id
-        WHERE ni.del_flag = 0 AND ni.status = 1
-          AND ni.task_id IN
-            <foreach collection="taskIds" item="id" open="(" separator="," close=")">
-                #{id}
-            </foreach>
-        ORDER BY ni.task_id, ni.order_no, ni.id
-    </select>
-
     <select id="selectTaskStatus" resultType="int">
         SELECT status FROM tc_task WHERE id = #{taskId} AND del_flag = 0 FOR UPDATE
-    </select>
-
-    <select id="countDoneNodeInst" resultType="long">
-        SELECT COUNT(*) FROM tc_task_node_inst
-        WHERE task_id = #{taskId} AND del_flag = 0 AND status = 2 FOR UPDATE
     </select>
 
     <update id="updateTaskCancel">
@@ -175,14 +113,6 @@
             update_by = #{userId},
             update_time = NOW()
         WHERE id = #{taskId} AND del_flag = 0
-    </update>
-
-    <update id="updateNodeInstCancel">
-        UPDATE tc_task_node_inst
-        SET status = 3,
-            update_by = #{userId},
-            update_time = NOW()
-        WHERE task_id = #{taskId} AND del_flag = 0 AND status IN (0,1)
     </update>
 
     <select id="selectTaskForEdit" resultType="com.zjlab.dataservice.modules.tc.model.dto.TaskManagerEditInfo">
@@ -203,59 +133,9 @@
         WHERE id = #{dto.taskId} AND del_flag = 0
     </update>
 
-    <select id="selectEndNodeInstIds" resultType="long">
-        SELECT id FROM tc_task_node_inst
-        WHERE task_id = #{taskId} AND del_flag = 0 AND JSON_LENGTH(next_node_ids) = 0
-    </select>
-
-    <insert id="insertViewNodeInst">
-        INSERT INTO tc_task_node_inst(
-            task_id, template_id, node_id, prev_node_ids, next_node_ids,
-            arrived_count, handler_role_ids, order_no, status, max_duration,
-            create_by, create_time, update_by, update_time
-        ) VALUES (
-            #{taskId}, #{templateId}, #{nodeId}, #{prevNodeIds}, '[]',
-            0, #{handlerRoleIds}, NULL, 0, NULL,
-            #{userId}, NOW(), #{userId}, NOW()
-        )
-    </insert>
-
     <select id="selectLastInsertId" resultType="long">
         SELECT LAST_INSERT_ID()
     </select>
-
-    <update id="appendViewNodeToEndNodes">
-        UPDATE tc_task_node_inst
-        SET next_node_ids = JSON_ARRAY_APPEND(next_node_ids, '$', #{nodeInstId}),
-            update_by = #{userId},
-            update_time = NOW()
-        WHERE id IN
-        <foreach collection="endInstIds" item="id" open="(" separator="," close=")">
-            #{id}
-        </foreach>
-    </update>
-
-    <select id="selectViewNodeInstId" resultType="long">
-        SELECT id FROM tc_task_node_inst
-        WHERE task_id = #{taskId} AND node_id = #{nodeId} AND del_flag = 0
-    </select>
-
-    <update id="deleteNodeInst">
-        UPDATE tc_task_node_inst
-        SET del_flag = 1,
-            update_by = #{userId},
-            update_time = NOW()
-        WHERE id = #{nodeInstId} AND del_flag = 0
-    </update>
-
-    <update id="clearEndNodeNext">
-        UPDATE tc_task_node_inst
-        SET next_node_ids = '[]',
-            update_by = #{userId},
-            update_time = NOW()
-        WHERE task_id = #{taskId} AND del_flag = 0
-          AND JSON_CONTAINS(next_node_ids, CAST(#{nodeInstId} AS JSON), '$')
-    </update>
 
     <select id="selectUserIdsByRoleIds" resultType="string">
         SELECT DISTINCT ur.user_id
@@ -264,29 +144,6 @@
         <foreach collection="roleIds" item="id" open="(" separator="," close=")">
             #{id}
         </foreach>
-    </select>
-
-    <select id="selectNextNodeIds" resultType="string">
-        SELECT next_node_ids FROM tc_task_node_inst
-        WHERE id = #{nodeInstId} AND del_flag = 0
-    </select>
-
-    <update id="increaseArrivedCount">
-        UPDATE tc_task_node_inst
-        SET arrived_count = arrived_count + 1,
-            update_by = #{userId},
-            update_time = NOW()
-        WHERE id = #{nodeInstId} AND del_flag = 0
-    </update>
-
-    <select id="selectHandlerRoleIds" resultType="string">
-        SELECT handler_role_ids FROM tc_task_node_inst
-        WHERE id = #{nodeInstId} AND del_flag = 0
-    </select>
-
-    <select id="countOngoingNodeInst" resultType="long">
-        SELECT COUNT(*) FROM tc_task_node_inst
-        WHERE task_id = #{taskId} AND del_flag = 0 AND status IN (0,1)
     </select>
 
     <update id="updateTaskComplete">
@@ -304,19 +161,6 @@
             update_time = NOW()
         WHERE id = #{taskId} AND del_flag = 0
     </update>
-
-    <update id="updateNodeInstAbort">
-        UPDATE tc_task_node_inst
-        SET status = 4,
-            update_by = #{userId},
-            update_time = NOW()
-        WHERE task_id = #{taskId} AND del_flag = 0 AND status IN (0,1)
-    </update>
-
-    <select id="selectNodeInstStatus" resultType="int">
-        SELECT status FROM tc_task_node_inst
-        WHERE id = #{nodeInstId} AND del_flag = 0
-    </select>
 
     <select id="selectTemplateNodeFlows" resultType="com.zjlab.dataservice.modules.tc.model.vo.TemplateNodeFlowVO">
         SELECT

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskNodeInstMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskNodeInstMapper.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.zjlab.dataservice.modules.tc.mapper.TcTaskNodeInstMapper">
+
+    <insert id="insertNodeInst">
+        INSERT INTO tc_task_node_inst(
+            task_id, template_id, node_id, prev_node_ids, next_node_ids,
+            arrived_count, handler_role_ids, order_no, status, max_duration,
+            create_by, create_time, update_by, update_time
+        ) VALUES (
+            #{taskId}, #{templateId}, #{nodeId}, '[]', '[]',
+            0, #{handlerRoleIds}, #{orderNo}, 0, #{maxDuration},
+            #{userId}, NOW(), #{userId}, NOW()
+        )
+    </insert>
+
+    <update id="updateNodeInstPrevNext">
+        UPDATE tc_task_node_inst
+        SET prev_node_ids = #{prevNodeIds},
+            next_node_ids = #{nextNodeIds},
+            update_by = #{userId},
+            update_time = NOW()
+        WHERE id = #{nodeInstId} AND del_flag = 0
+    </update>
+
+    <update id="activateNodeInst">
+        UPDATE tc_task_node_inst
+        SET status = 1,
+            started_at = NOW(),
+            update_by = #{userId},
+            update_time = NOW()
+        WHERE id = #{nodeInstId} AND status = 0 AND del_flag = 0
+          AND arrived_count &gt;= JSON_LENGTH(prev_node_ids)
+    </update>
+
+    <update id="completeNodeInst">
+        UPDATE tc_task_node_inst
+        SET status = 2,
+            completed_at = NOW(),
+            completed_by = #{userId},
+            update_by = #{userId},
+            update_time = NOW()
+        WHERE id = #{nodeInstId} AND status = 1 AND del_flag = 0
+    </update>
+
+    <select id="selectCurrentNodes" resultType="com.zjlab.dataservice.modules.tc.model.dto.CurrentNodeRow">
+        SELECT
+            ni.task_id AS taskId,
+            ni.id AS nodeInstId,
+            ninfo.name AS nodeName,
+            ni.handler_role_ids AS handlerRoleIds
+        FROM tc_task_node_inst ni
+        JOIN tc_node_info ninfo ON ninfo.id = ni.node_id
+        WHERE ni.del_flag = 0 AND ni.status = 1
+          AND ni.task_id IN
+            <foreach collection="taskIds" item="id" open="(" separator="," close=")">
+                #{id}
+            </foreach>
+        ORDER BY ni.task_id, ni.order_no, ni.id
+    </select>
+
+    <select id="countDoneNodeInst" resultType="long">
+        SELECT COUNT(*) FROM tc_task_node_inst
+        WHERE task_id = #{taskId} AND del_flag = 0 AND status = 2 FOR UPDATE
+    </select>
+
+    <update id="updateNodeInstCancel">
+        UPDATE tc_task_node_inst
+        SET status = 3,
+            update_by = #{userId},
+            update_time = NOW()
+        WHERE task_id = #{taskId} AND del_flag = 0 AND status IN (0,1)
+    </update>
+
+    <select id="selectEndNodeInstIds" resultType="long">
+        SELECT id FROM tc_task_node_inst
+        WHERE task_id = #{taskId} AND del_flag = 0 AND JSON_LENGTH(next_node_ids) = 0
+    </select>
+
+    <insert id="insertViewNodeInst">
+        INSERT INTO tc_task_node_inst(
+            task_id, template_id, node_id, prev_node_ids, next_node_ids,
+            arrived_count, handler_role_ids, order_no, status, max_duration,
+            create_by, create_time, update_by, update_time
+        ) VALUES (
+            #{taskId}, #{templateId}, #{nodeId}, #{prevNodeIds}, '[]',
+            0, #{handlerRoleIds}, NULL, 0, NULL,
+            #{userId}, NOW(), #{userId}, NOW()
+        )
+    </insert>
+
+    <select id="selectLastInsertId" resultType="long">
+        SELECT LAST_INSERT_ID()
+    </select>
+
+    <update id="appendViewNodeToEndNodes">
+        UPDATE tc_task_node_inst
+        SET next_node_ids = JSON_ARRAY_APPEND(next_node_ids, '$', #{nodeInstId}),
+            update_by = #{userId},
+            update_time = NOW()
+        WHERE id IN
+        <foreach collection="endInstIds" item="id" open="(" separator="," close=")">
+            #{id}
+        </foreach>
+    </update>
+
+    <select id="selectViewNodeInstId" resultType="long">
+        SELECT id FROM tc_task_node_inst
+        WHERE task_id = #{taskId} AND node_id = #{nodeId} AND del_flag = 0
+    </select>
+
+    <update id="deleteNodeInst">
+        UPDATE tc_task_node_inst
+        SET del_flag = 1,
+            update_by = #{userId},
+            update_time = NOW()
+        WHERE id = #{nodeInstId} AND del_flag = 0
+    </update>
+
+    <update id="clearEndNodeNext">
+        UPDATE tc_task_node_inst
+        SET next_node_ids = '[]',
+            update_by = #{userId},
+            update_time = NOW()
+        WHERE task_id = #{taskId} AND del_flag = 0
+          AND JSON_CONTAINS(next_node_ids, CAST(#{nodeInstId} AS JSON), '$')
+    </update>
+
+    <select id="selectNextNodeIds" resultType="string">
+        SELECT next_node_ids FROM tc_task_node_inst
+        WHERE id = #{nodeInstId} AND del_flag = 0
+    </select>
+
+    <update id="increaseArrivedCount">
+        UPDATE tc_task_node_inst
+        SET arrived_count = arrived_count + 1,
+            update_by = #{userId},
+            update_time = NOW()
+        WHERE id = #{nodeInstId} AND del_flag = 0
+    </update>
+
+    <select id="selectHandlerRoleIds" resultType="string">
+        SELECT handler_role_ids FROM tc_task_node_inst
+        WHERE id = #{nodeInstId} AND del_flag = 0
+    </select>
+
+    <select id="countOngoingNodeInst" resultType="long">
+        SELECT COUNT(*) FROM tc_task_node_inst
+        WHERE task_id = #{taskId} AND del_flag = 0 AND status IN (0,1)
+    </select>
+
+    <update id="updateNodeInstAbort">
+        UPDATE tc_task_node_inst
+        SET status = 4,
+            update_by = #{userId},
+            update_time = NOW()
+        WHERE task_id = #{taskId} AND del_flag = 0 AND status IN (0,1)
+    </update>
+
+    <select id="selectNodeInstStatus" resultType="int">
+        SELECT status FROM tc_task_node_inst
+        WHERE id = #{nodeInstId} AND del_flag = 0
+    </select>
+
+</mapper>


### PR DESCRIPTION
## Summary
- move node instance queries from `TcTaskManagerMapper` into new `TcTaskNodeInstMapper`
- update service layer to use new mapper
- keep `TcTaskManagerMapper` focused on task-level queries

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68abffe183c08330a824a625e7758f07