### PR TITLE
feat: add realtime orbit plan query endpoint

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcTaskManagerController.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcTaskManagerController.java
@@ -124,6 +124,14 @@ public class TcTaskManagerController {
         return Result.ok(taskManagerService.getOrbitPlans(taskId));
     }
 
+    @GetMapping("/orbitPlans/realtime")
+    @ApiOperationSupport(order = 11)
+    @ApiOperation(value = "查询实时轨道计划", notes = "调用测运控接口实时获取轨道计划")
+    public Result<List<OrbitPlanExportVO>> getOrbitPlansRealtime(@RequestParam Long taskId) {
+        // TODO 调用测运控接口实时计算轨道计划
+        return Result.ok(taskManagerService.getRealtimeOrbitPlans(taskId));
+    }
+
     @GetMapping("/nodeFlows")
     @ApiOperationSupport(order = 6)
     @ApiOperation(value = "查询模板节点流", notes = "根据模板ID获取节点流列表")

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/TcTaskManagerService.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/TcTaskManagerService.java
@@ -85,4 +85,12 @@ public interface TcTaskManagerService {
      * @return 轨道计划列表
      */
     List<OrbitPlanExportVO> getOrbitPlans(Long taskId);
+
+    /**
+     * 实时查询轨道计划
+     *
+     * @param taskId 任务ID
+     * @return 轨道计划列表
+     */
+    List<OrbitPlanExportVO> getRealtimeOrbitPlans(Long taskId);
 }

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
@@ -730,4 +730,10 @@ public class TcTaskManagerServiceImpl implements TcTaskManagerService {
         }
         return JSON.parseArray(json, OrbitPlanExportVO.class);
     }
+
+    @Override
+    public List<OrbitPlanExportVO> getRealtimeOrbitPlans(Long taskId) {
+        // TODO 调用测运控接口实时计算轨道计划
+        return Collections.emptyList();
+    }
 }


### PR DESCRIPTION
## Summary
- add realtime orbit plan query endpoint in `TcTaskManagerController`
- define service API and stub implementation for realtime orbit plan retrieval

## Testing
- `mvn -q -pl system/biz -am test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3f7fffc883308e1e5f07810c0e4f