### PR TITLE
Remove taskId parameter from realtime orbit plan API

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcTaskManagerController.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcTaskManagerController.java
@@ -127,9 +127,9 @@ public class TcTaskManagerController {
     @GetMapping("/orbitPlans/realtime")
     @ApiOperationSupport(order = 11)
     @ApiOperation(value = "查询实时轨道计划", notes = "调用测运控接口实时获取轨道计划")
-    public Result<List<OrbitPlanExportVO>> getOrbitPlansRealtime(@RequestParam Long taskId) {
+    public Result<List<OrbitPlanExportVO>> getOrbitPlansRealtime() {
         // TODO 调用测运控接口实时计算轨道计划
-        return Result.ok(taskManagerService.getRealtimeOrbitPlans(taskId));
+        return Result.ok(taskManagerService.getRealtimeOrbitPlans());
     }
 
     @GetMapping("/nodeFlows")

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/TcTaskManagerService.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/TcTaskManagerService.java
@@ -89,8 +89,7 @@ public interface TcTaskManagerService {
     /**
      * 实时查询轨道计划
      *
-     * @param taskId 任务ID
      * @return 轨道计划列表
      */
-    List<OrbitPlanExportVO> getRealtimeOrbitPlans(Long taskId);
+    List<OrbitPlanExportVO> getRealtimeOrbitPlans();
 }

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
@@ -732,7 +732,7 @@ public class TcTaskManagerServiceImpl implements TcTaskManagerService {
     }
 
     @Override
-    public List<OrbitPlanExportVO> getRealtimeOrbitPlans(Long taskId) {
+    public List<OrbitPlanExportVO> getRealtimeOrbitPlans() {
         // TODO 调用测运控接口实时计算轨道计划
         return Collections.emptyList();
     }


### PR DESCRIPTION
## Summary
- drop taskId parameter from realtime orbit plan controller endpoint
- update service interface and implementation accordingly

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ad49a9c3b08330bda0bad6a913ed36