### PR TITLE
Remove export subtitle for task manager Excel

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcTaskManagerController.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcTaskManagerController.java
@@ -89,7 +89,7 @@ public class TcTaskManagerController {
         mv.addObject(NormalExcelConstants.FILE_NAME, "遥控指令单");
         mv.addObject(NormalExcelConstants.CLASS, RemoteCmdExportVO.class);
         mv.addObject(NormalExcelConstants.PARAMS,
-                new ExportParams("遥控指令单", "导出人:" + taskManagerService.getCurrentUserRealName(), "遥控指令单"));
+                new ExportParams("遥控指令单", "遥控指令单"));
         mv.addObject(NormalExcelConstants.DATA_LIST, list);
         return mv;
     }
@@ -102,7 +102,7 @@ public class TcTaskManagerController {
         mv.addObject(NormalExcelConstants.FILE_NAME, "测运控仿真轨道计划");
         mv.addObject(NormalExcelConstants.CLASS, OrbitPlanExportVO.class);
         mv.addObject(NormalExcelConstants.PARAMS,
-                new ExportParams("测运控仿真轨道计划", "导出人:" + taskManagerService.getCurrentUserRealName(), "轨道计划"));
+                new ExportParams("测运控仿真轨道计划", "轨道计划"));
         mv.addObject(NormalExcelConstants.DATA_LIST, list);
         return mv;
     }

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/TcTaskManagerService.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/TcTaskManagerService.java
@@ -101,10 +101,4 @@ public interface TcTaskManagerService {
      */
     TaskCountVO countTasks();
 
-    /**
-     * 获取当前登录用户真实姓名
-     *
-     * @return 真实姓名，获取失败返回空字符串
-     */
-    String getCurrentUserRealName();
 }

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
@@ -770,13 +770,4 @@ public class TcTaskManagerServiceImpl implements TcTaskManagerService {
         return vo;
     }
 
-    @Override
-    public String getCurrentUserRealName() {
-        String userId = UserThreadLocal.getUserId();
-        if (userId == null) {
-            return "";
-        }
-        SysUser user = sysUserService.getById(userId);
-        return user != null ? user.getRealname() : "";
-    }
 }


### PR DESCRIPTION
## Summary
- simplify export of remote commands and orbit plans by dropping secondary "exporter" subtitle
- remove unused getCurrentUserRealName service method

## Testing
- `mvn -q -pl system/biz -am test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d7241020833086e5cc50267ffe1a