### PR TITLE
fix: parse template nodes correctly

### DIFF
--- a/doc/taskManager.md
+++ b/doc/taskManager.md
@@ -777,6 +777,7 @@ ORDER BY r.create_time DESC;
 ---
 
 ## 7. 任务模板中的工作流信息，采用logicflow（参考https://site.logic-flow.cn/）的数据结构，该字段以json存在tc_todo_template的template_attr字段。
+template_attr保存LogicFlow的节点与连线信息，其中节点配置位于 `nodes[].properties.nodeConfigParams`，节点定义ID存放在 `nodeConfigParams.id`。
 示例数据：
 {
   "nodes": [

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcNodeServiceImpl.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcNodeServiceImpl.java
@@ -66,20 +66,32 @@ public class TcNodeServiceImpl implements TcNodeService {
             if (attr == null) {
                 continue;
             }
-            Object nodeConfigs = attr.get("nodeConfigParams");
-            if (nodeConfigs instanceof List) {
-                for (Object obj : (List<?>) nodeConfigs) {
-                    if (obj instanceof Map) {
-                        Object idObj = ((Map<?, ?>) obj).get("id");
-                        if (idObj != null) {
-                            try {
-                                long id = Long.parseLong(String.valueOf(idObj));
-                                if (id == nodeId) {
-                                    return true;
-                                }
-                            } catch (NumberFormatException ignore) {
-                            }
+            Object nodesObj = attr.get("nodes");
+            if (!(nodesObj instanceof List)) {
+                continue;
+            }
+            for (Object nodeObj : (List<?>) nodesObj) {
+                if (!(nodeObj instanceof Map)) {
+                    continue;
+                }
+                Map<?, ?> nodeMap = (Map<?, ?>) nodeObj;
+                Object propertiesObj = nodeMap.get("properties");
+                if (!(propertiesObj instanceof Map)) {
+                    continue;
+                }
+                Map<?, ?> propertiesMap = (Map<?, ?>) propertiesObj;
+                Object cfgObj = propertiesMap.get("nodeConfigParams");
+                if (!(cfgObj instanceof Map)) {
+                    continue;
+                }
+                Object idObj = ((Map<?, ?>) cfgObj).get("id");
+                if (idObj != null) {
+                    try {
+                        long id = Long.parseLong(String.valueOf(idObj));
+                        if (id == nodeId) {
+                            return true;
                         }
+                    } catch (NumberFormatException ignore) {
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- correct logic flow template parsing in node reference check
- document location of nodeConfigParams in task templates

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f8cb1aa883309fefee6ec28c09d6