### PR TITLE
fix: set order and duration for view result node

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/TcTaskNodeInstMapper.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/TcTaskNodeInstMapper.java
@@ -43,6 +43,8 @@ public interface TcTaskNodeInstMapper {
                            @Param("nodeId") Long nodeId,
                            @Param("prevNodeIds") String prevNodeIds,
                            @Param("handlerRoleIds") String handlerRoleIds,
+                           @Param("orderNo") Integer orderNo,
+                           @Param("maxDuration") Integer maxDuration,
                            @Param("actions") String actions,
                            @Param("userId") String userId);
 
@@ -71,6 +73,8 @@ public interface TcTaskNodeInstMapper {
     int updateNodeInstAbort(@Param("taskId") Long taskId, @Param("userId") String userId);
 
     Integer selectNodeInstStatus(@Param("nodeInstId") Long nodeInstId);
+
+    Integer selectMaxOrderNo(@Param("taskId") Long taskId);
 
     /** 按任务ID查询所有节点实例 */
     List<TaskNodeVO> selectNodeInstsByTaskId(@Param("taskId") Long taskId);

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskNodeInstMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskNodeInstMapper.xml
@@ -77,6 +77,11 @@
         WHERE task_id = #{taskId} AND del_flag = 0 AND JSON_LENGTH(next_node_ids) = 0
     </select>
 
+    <select id="selectMaxOrderNo" resultType="int">
+        SELECT MAX(order_no) FROM tc_task_node_inst
+        WHERE task_id = #{taskId} AND del_flag = 0
+    </select>
+
     <insert id="insertViewNodeInst">
         INSERT INTO tc_task_node_inst(
             task_id, template_id, node_id, prev_node_ids, next_node_ids,
@@ -84,7 +89,7 @@
             create_by, create_time, update_by, update_time
         ) VALUES (
             #{taskId}, #{templateId}, #{nodeId}, #{prevNodeIds}, '[]',
-            0, #{handlerRoleIds}, NULL, 0, NULL, #{actions},
+            0, #{handlerRoleIds}, #{orderNo}, 0, #{maxDuration}, #{actions},
             #{userId}, NOW(), #{userId}, NOW()
         )
     </insert>

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
@@ -177,7 +177,10 @@ public class TcTaskManagerServiceImpl implements TcTaskManagerService {
                     List<String> roleIds = rels.stream().map(NodeRoleRel::getRoleId).collect(Collectors.toList());
                     String prevNodeIds = JSON.toJSONString(endIds);
                     String handlerRoleIds = JSON.toJSONString(roleIds);
-                    taskNodeInstMapper.insertViewNodeInst(taskId, dto.getTemplateId(), viewNode.getId(), prevNodeIds, handlerRoleIds, viewNode.getActions(), userId);
+                    Integer maxOrderNo = taskNodeInstMapper.selectMaxOrderNo(taskId);
+                    Integer orderNo = maxOrderNo == null ? 1 : maxOrderNo + 1;
+                    Integer maxDuration = viewNode.getExpectedDuration();
+                    taskNodeInstMapper.insertViewNodeInst(taskId, dto.getTemplateId(), viewNode.getId(), prevNodeIds, handlerRoleIds, orderNo, maxDuration, viewNode.getActions(), userId);
                     Long viewInstId = taskNodeInstMapper.selectLastInsertId();
                     if (viewInstId != null) {
                         taskNodeInstMapper.appendViewNodeToEndNodes(viewInstId, endIds, userId);
@@ -415,7 +418,10 @@ public class TcTaskManagerServiceImpl implements TcTaskManagerService {
                     List<String> roleIds = rels.stream().map(NodeRoleRel::getRoleId).collect(Collectors.toList());
                     String prevNodeIds = JSON.toJSONString(endIds);
                     String handlerRoleIds = JSON.toJSONString(roleIds);
-                    taskNodeInstMapper.insertViewNodeInst(dto.getTaskId(), info.getTemplateId(), viewNode.getId(), prevNodeIds, handlerRoleIds, viewNode.getActions(), userId);
+                    Integer maxOrderNo = taskNodeInstMapper.selectMaxOrderNo(dto.getTaskId());
+                    Integer orderNo = maxOrderNo == null ? 1 : maxOrderNo + 1;
+                    Integer maxDuration = viewNode.getExpectedDuration();
+                    taskNodeInstMapper.insertViewNodeInst(dto.getTaskId(), info.getTemplateId(), viewNode.getId(), prevNodeIds, handlerRoleIds, orderNo, maxDuration, viewNode.getActions(), userId);
                     Long viewInstId = taskNodeInstMapper.selectLastInsertId();
                     if (viewInstId != null) {
                         taskNodeInstMapper.appendViewNodeToEndNodes(viewInstId, endIds, userId);


### PR DESCRIPTION
## Summary
- ensure view result node instances include order number and max duration
- support computing next order number when adding view result node

## Testing
- `mvn -q -pl system/biz -am test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b94dabcbc88330bb120a38d32b4664