### PR TITLE
feat: support optional imaging result node in node flows

### DIFF
--- a/doc/taskManager.md
+++ b/doc/taskManager.md
@@ -672,6 +672,9 @@ Resp：`[OrbitPlanExportVO]`
 
 Resp（统一分页）：`{ list: [...], total: number }`
 
+模板节点流 `GET /task/nodeFlows?templateId=&resultDisplayNeeded=0|1`（resultDisplayNeeded 必传）
+Resp：`[TemplateNodeFlowVO]` 按 `orderNo` 升序排列（resultDisplayNeeded=1 时列表末尾追加“查看影像结果”节点）
+
 ### 3.2 节点办理
 
 提交动作 `POST /task/node/submit`

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcTaskManagerController.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcTaskManagerController.java
@@ -132,8 +132,9 @@ public class TcTaskManagerController {
     @GetMapping("/nodeFlows")
     @ApiOperationSupport(order = 6)
     @ApiOperation(value = "查询模板节点流", notes = "根据模板ID获取节点流列表")
-    public Result<List<TemplateNodeFlowVO>> nodeFlows(@RequestParam String templateId) {
-        List<TemplateNodeFlowVO> flows = taskManagerService.listNodeFlows(templateId);
+    public Result<List<TemplateNodeFlowVO>> nodeFlows(@RequestParam String templateId,
+                                                     @RequestParam Integer resultDisplayNeeded) {
+        List<TemplateNodeFlowVO> flows = taskManagerService.listNodeFlows(templateId, resultDisplayNeeded);
         return Result.ok(flows);
     }
 

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/TcTaskManagerService.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/TcTaskManagerService.java
@@ -52,9 +52,10 @@ public interface TcTaskManagerService {
      * 根据任务模板ID查询节点流
      *
      * @param templateId 模板ID
+     * @param resultDisplayNeeded 是否需要结果展示（0 或 1，必传）
      * @return 节点流列表
      */
-    List<TemplateNodeFlowVO> listNodeFlows(String templateId);
+    List<TemplateNodeFlowVO> listNodeFlows(String templateId, Integer resultDisplayNeeded);
 
     /**
      * 提交节点操作


### PR DESCRIPTION
## Summary
- allow querying template node flows with optional result display flag
- append "查看影像结果" node to flows when resultDisplayNeeded=1
- order node flow results by orderNo ascending
- document new nodeFlows parameter and behavior
- require explicit resultDisplayNeeded parameter, no default applied

## Testing
- `mvn -q -e -pl system/biz -am test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b95295c5548330bbb119ad8cf63cf7