### PR TITLE
refactor: drop tenant_id from notify module

### DIFF
--- a/doc/notify.md
+++ b/doc/notify.md
@@ -40,6 +40,8 @@
 
 存放“要发”的一条通知任务（收件人由模板展开后写入明细表）。
 
+> 该模块为单租户设计，表结构中不包含 `tenant_id` 字段。
+
 ```sql
 CREATE TABLE `tc_notify_job` (
   `id` BIGINT PRIMARY KEY AUTO_INCREMENT COMMENT '通知任务ID',

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/mapper/xml/NotifyJobMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/mapper/xml/NotifyJobMapper.xml
@@ -21,7 +21,7 @@
     </select>
 
     <select id="lockDueJobs" resultType="com.zjlab.dataservice.modules.notify.model.entity.NotifyJob">
-        SELECT id, tenant_id, del_flag, create_by, create_time, update_by, update_time,
+        SELECT id, del_flag, create_by, create_time, update_by, update_time,
                biz_type, biz_id, dedup_key, payload, channel, status, retry_count, next_run_time, remark
         FROM tc_notify_job
         WHERE status = 0

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/mapper/xml/NotifyRecipientMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/mapper/xml/NotifyRecipientMapper.xml
@@ -11,7 +11,7 @@
     </insert>
 
     <select id="findByJobId" resultType="com.zjlab.dataservice.modules.notify.model.entity.NotifyRecipient">
-        SELECT id, tenant_id, del_flag, create_by, create_time, update_by, update_time,
+        SELECT id, del_flag, create_by, create_time, update_by, update_time,
                job_id, user_id, status, last_error
         FROM tc_notify_recipient
         WHERE job_id = #{jobId}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/mapper/xml/NotifyTemplateMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/mapper/xml/NotifyTemplateMapper.xml
@@ -3,7 +3,7 @@
 <mapper namespace="com.zjlab.dataservice.modules.notify.mapper.NotifyTemplateMapper">
 
     <select id="selectByBizAndChannel" resultType="com.zjlab.dataservice.modules.notify.model.entity.NotifyTemplate">
-        SELECT id, tenant_id, del_flag, create_by, create_time, update_by, update_time,
+        SELECT id, del_flag, create_by, create_time, update_by, update_time,
                biz_type, channel, title_tpl, content_tpl, enabled
         FROM tc_notify_template
         WHERE biz_type = #{bizType}


### PR DESCRIPTION
## Summary
- remove tenant_id usage in notify mappers
- note single-tenant design in notify documentation

## Testing
- `mvn -q -pl system/biz -am test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68bab58472608330a594b80ce33aee22