### PR TITLE
feat: include remote data in task detail

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskManagerMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskManagerMapper.xml
@@ -123,6 +123,8 @@
         <result column="taskName" property="taskName"/>
         <result column="taskType" property="taskType"/>
         <result column="satellites" property="satellitesJson"/>
+        <result column="remoteCmds" property="remoteCmdsJson"/>
+        <result column="orbitPlans" property="orbitPlansJson"/>
         <result column="createTime" property="createTime"/>
         <result column="status" property="status"/>
         <result column="taskRequirement" property="taskRequirement"/>
@@ -134,6 +136,8 @@
                t.task_name AS taskName,
                tt.template_name AS taskType,
                t.satellites AS satellites,
+               t.remote_cmds AS remoteCmds,
+               t.orbit_plans AS orbitPlans,
                t.create_time AS createTime,
                t.status AS status,
                t.task_requirement AS taskRequirement,

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/vo/TaskDetailVO.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/vo/TaskDetailVO.java
@@ -15,6 +15,12 @@ public class TaskDetailVO extends TaskBaseVO {
     private List<SatelliteGroupVO> satellites;
     @JsonIgnore
     private String satellitesJson;
+    private List<RemoteCmdExportVO> remoteCmds;
+    @JsonIgnore
+    private String remoteCmdsJson;
+    private List<OrbitPlanExportVO> orbitPlans;
+    @JsonIgnore
+    private String orbitPlansJson;
     private String taskRequirement;
     private String imagingArea;
     private List<TaskHistoryNodeVO> history;

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/vo/TaskNodeActionVO.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/vo/TaskNodeActionVO.java
@@ -3,7 +3,6 @@ package com.zjlab.dataservice.modules.tc.model.vo;
 import lombok.Data;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
 
 /** 节点操作记录信息 */
 @Data
@@ -12,12 +11,6 @@ public class TaskNodeActionVO implements Serializable {
     private static final long serialVersionUID = 8431966549122817451L;
     /** 节点实例ID */
     private Long nodeInstId;
-    /** 操作时间 */
-    private LocalDateTime actionTime;
-    /** 操作人ID */
-    private String operatorId;
-    /** 操作人名称 */
-    private String operatorName;
     /** 操作类型 */
     private Integer actionType;
     /** 提交内容JSON */

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
@@ -711,6 +711,12 @@ public class TcTaskManagerServiceImpl implements TcTaskManagerService {
         if (StringUtils.isNotBlank(detail.getSatellitesJson())) {
             detail.setSatellites(JSON.parseArray(detail.getSatellitesJson(), SatelliteGroupVO.class));
         }
+        if (StringUtils.isNotBlank(detail.getRemoteCmdsJson())) {
+            detail.setRemoteCmds(JSON.parseArray(detail.getRemoteCmdsJson(), RemoteCmdExportVO.class));
+        }
+        if (StringUtils.isNotBlank(detail.getOrbitPlansJson())) {
+            detail.setOrbitPlans(JSON.parseArray(detail.getOrbitPlansJson(), OrbitPlanExportVO.class));
+        }
 
         // 3. 查询当前节点信息
         List<CurrentNodeRow> rows = taskNodeInstMapper.selectCurrentNodes(Collections.singletonList(taskId));
@@ -803,28 +809,12 @@ public class TcTaskManagerServiceImpl implements TcTaskManagerService {
         List<TaskNodeActionRecord> records = actionRecordMapper.selectList(
                 new QueryWrapper<TaskNodeActionRecord>().eq("task_id", taskId).orderByAsc("create_time"));
         if (!records.isEmpty()) {
-            Set<String> userIds = records.stream().map(TaskNodeActionRecord::getCreateBy)
-                    .filter(StringUtils::isNotBlank).collect(Collectors.toSet());
-            Map<String, String> userNameMap = new HashMap<>();
-            if (!userIds.isEmpty()) {
-                List<SysUser> users = sysUserService.listByIds(userIds);
-                if (users != null) {
-                    for (SysUser u : users) {
-                        userNameMap.put(u.getId(), u.getRealname());
-                    }
-                }
-            }
             for (TaskNodeActionRecord r : records) {
                 // 组装单条操作日志
                 TaskNodeActionVO av = new TaskNodeActionVO();
                 av.setNodeInstId(r.getNodeInstId());
                 av.setActionType(r.getActionType());
                 av.setActionPayload(r.getActionPayload());
-                av.setActionTime(r.getCreateTime());
-                av.setOperatorId(r.getCreateBy());
-                if (StringUtils.isNotBlank(r.getCreateBy())) {
-                    av.setOperatorName(userNameMap.get(r.getCreateBy()));
-                }
                 TaskHistoryNodeVO hv = historyMap.get(r.getNodeInstId());
                 if (hv != null) {
                     hv.getActionLogs().add(av);


### PR DESCRIPTION
## Summary
- expose remote command and orbit plan lists on task detail
- drop operator/time fields from task action logs

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM for org.jeecgframework.boot:jeecg-boot-parent:3.5.1)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe498364c83309fbfa73438e93a5e