### PR TITLE
feat: support multi-actions node submission

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcTaskManagerController.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcTaskManagerController.java
@@ -13,11 +13,14 @@ import com.zjlab.dataservice.modules.tc.model.vo.OrbitPlanExportVO;
 import com.zjlab.dataservice.modules.tc.model.vo.TemplateNodeFlowVO;
 import com.zjlab.dataservice.modules.tc.model.vo.TaskDetailVO;
 import com.zjlab.dataservice.modules.tc.model.vo.TaskCountVO;
+import com.zjlab.dataservice.modules.tc.model.vo.TaskNodeActionVO;
+import com.alibaba.fastjson.JSON;
 import com.zjlab.dataservice.modules.tc.service.TcTaskManagerService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.multipart.MultipartFile;
 import org.jeecgframework.poi.excel.entity.ExportParams;
 import org.jeecgframework.poi.excel.def.NormalExcelConstants;
 import org.jeecgframework.poi.excel.view.JeecgEntityExcelView;
@@ -138,11 +142,18 @@ public class TcTaskManagerController {
         return Result.ok(flows);
     }
 
-    @PostMapping("/node/submit")
+    @PostMapping(value = "/node/submit", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ApiOperationSupport(order = 7)
     @ApiOperation(value = "提交节点操作", notes = "节点办理操作提交")
-    public Result<Void> submitNodeAction(@RequestBody @Valid NodeActionSubmitDto dto) {
-        taskManagerService.submitAction(dto);
+    public Result<Void> submitNodeAction(@RequestParam Long taskId,
+                                         @RequestParam Long nodeInstId,
+                                         @RequestParam String actions,
+                                         @RequestParam(value = "files", required = false) MultipartFile[] files) {
+        NodeActionSubmitDto dto = new NodeActionSubmitDto();
+        dto.setTaskId(taskId);
+        dto.setNodeInstId(nodeInstId);
+        dto.setActions(JSON.parseArray(actions, TaskNodeActionVO.class));
+        taskManagerService.submitAction(dto, files);
         return Result.ok();
     }
 

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeActionSubmitDto.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeActionSubmitDto.java
@@ -1,9 +1,12 @@
 package com.zjlab.dataservice.modules.tc.model.dto;
 
+import com.zjlab.dataservice.modules.tc.model.vo.TaskNodeActionVO;
 import lombok.Data;
 
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.io.Serializable;
+import java.util.List;
 
 /**
  * 节点操作提交参数
@@ -17,9 +20,7 @@ public class NodeActionSubmitDto implements Serializable {
     /** 节点实例ID */
     @NotNull
     private Long nodeInstId;
-    /** 操作类型(0上传,1选择计划,2决策,3文本等) */
-    @NotNull
-    private Integer actionType;
-    /** 提交内容JSON */
-    private String actionPayload;
+    /** 操作列表 */
+    @NotEmpty
+    private List<TaskNodeActionVO> actions;
 }

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/TcTaskManagerService.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/TcTaskManagerService.java
@@ -11,6 +11,7 @@ import com.zjlab.dataservice.modules.tc.model.vo.TaskDetailVO;
 import com.zjlab.dataservice.modules.tc.model.vo.RemoteCmdExportVO;
 import com.zjlab.dataservice.modules.tc.model.vo.OrbitPlanExportVO;
 import com.zjlab.dataservice.modules.tc.model.vo.TaskCountVO;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -60,9 +61,10 @@ public interface TcTaskManagerService {
     /**
      * 提交节点操作
      *
-     * @param dto 节点操作参数
+     * @param dto   节点操作参数
+     * @param files 上传的文件列表（用于 actionType=0 的上传操作）
      */
-    void submitAction(NodeActionSubmitDto dto);
+    void submitAction(NodeActionSubmitDto dto, MultipartFile[] files);
 
     /**
      * 查询任务详情


### PR DESCRIPTION
## Summary
- allow submitting multiple actions per node with TaskNodeActionVO
- handle file uploads for action types 0 and 4, storing attachments in MinIO
- parse multipart node submissions containing actions JSON and files

## Testing
- `mvn -q -pl system/biz -am -DskipTests package` *(fails: Non-resolvable parent POM: Name or service not known)*

------
https://chatgpt.com/codex/tasks/task_e_68c1055ac35083308713ad8156172f0c