### PR TITLE
feat: add error code for node decision action

### DIFF
--- a/common/src/main/java/com/zjlab/dataservice/common/constant/enums/ResultCode.java
+++ b/common/src/main/java/com/zjlab/dataservice/common/constant/enums/ResultCode.java
@@ -86,6 +86,7 @@ public enum ResultCode {
     TASKMANAGE_CANNOT_EDIT(210005, "已有节点处理，不能编辑"),
     TASKMANAGE_IMAGING_AREA_REQUIRED(210006, "成像区域不能为空"),
     NODE_ASSOCIATED_TEMPLATE(210007, "节点已关联任务模板，无法删除或禁用"),
+    NODE_ONLY_ONE_DECISION_ACTION(210008, "节点必须且只能有一个决策action"),
 
     ;
     //返回码

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcNodeServiceImpl.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcNodeServiceImpl.java
@@ -246,7 +246,7 @@ public class TcNodeServiceImpl implements TcNodeService {
                         .filter(a -> a.getType() != null && a.getType() == NodeActionTypeEnum.DECISION.getCode())
                         .count();
         if (decisionCount != 1) {
-            throw new BaseException(ResultCode.PARA_ERROR.getCode(), "有且只能有一个决策");
+            throw new BaseException(ResultCode.NODE_ONLY_ONE_DECISION_ACTION);
         }
 
         // 2. 转换DTO为实体并补充通用字段
@@ -307,7 +307,7 @@ public class TcNodeServiceImpl implements TcNodeService {
                         .filter(a -> a.getType() != null && a.getType() == NodeActionTypeEnum.DECISION.getCode())
                         .count();
         if (decisionCount != 1) {
-            throw new BaseException(ResultCode.PARA_ERROR.getCode(), "有且只能有一个决策");
+            throw new BaseException(ResultCode.NODE_ONLY_ONE_DECISION_ACTION);
         }
 
         NodeInfo exist = nodeInfoMapper.selectById(id);


### PR DESCRIPTION
## Summary
- add NODE_ONLY_ONE_DECISION_ACTION result code
- enforce single decision action during node creation and update

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM for jeecg-boot-parent: The following artifacts could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68c7aac1317c8330b65831e6cd7e5613