### PR TITLE
feat: validate single file in submit action

### DIFF
--- a/common/src/main/java/com/zjlab/dataservice/common/constant/enums/ResultCode.java
+++ b/common/src/main/java/com/zjlab/dataservice/common/constant/enums/ResultCode.java
@@ -87,6 +87,7 @@ public enum ResultCode {
     TASKMANAGE_IMAGING_AREA_REQUIRED(210006, "成像区域不能为空"),
     NODE_ASSOCIATED_TEMPLATE(210007, "节点已关联任务模板，无法删除或禁用"),
     NODE_ONLY_ONE_DECISION_ACTION(210008, "节点必须且只能有一个决策action"),
+    TASKMANAGE_UPLOAD_ONLY_ONE_FILE(210009, "上传操作只支持一个文件"),
 
     ;
     //返回码

--- a/doc/taskManager.md
+++ b/doc/taskManager.md
@@ -681,10 +681,10 @@ Resp：`[TemplateNodeFlowVO]` 按 `orderNo` 升序排列（resultDisplayNeeded=1
 表单字段（`multipart/form-data`）：
 
 ```
-taskId*, nodeInstId*, actions* (JSON字符串), files? (文件数组)
+taskId*, nodeInstId*, actions* (JSON字符串), files? (文件数组，仅支持单个文件)
 ```
 
-说明：`actions` 为 `[{actionType,payload}]` 列表，可一次提交多个动作；上传类动作的附件通过 `files` 字段传输。
+说明：`actions` 为 `[{actionType,payload}]` 列表，可一次提交多个动作；上传类动作的附件通过 `files` 字段传输（仅允许一个文件）。
 行为：按 §2.3 完成节点、推进后继、发放待办。
 Resp：`{ success: true }`（仅当前节点操作人可提交）
 

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
@@ -602,6 +602,10 @@ public class TcTaskManagerServiceImpl implements TcTaskManagerService {
                 || dto.getActions() == null || dto.getActions().isEmpty()) {
             throw new BaseException(ResultCode.PARA_ERROR);
         }
+        // files入参只能上传一个
+        if (files != null && files.length > 1) {
+            throw new BaseException(ResultCode.TASKMANAGE_UPLOAD_ONLY_ONE_FILE);
+        }
         // 2. 获取当前用户
         String userId = UserThreadLocal.getUserId();
         if (userId == null) {


### PR DESCRIPTION
## Summary
- add dedicated error code when multiple files are uploaded to node action
- ensure submitAction rejects uploads with more than one file

## Testing
- `mvn -q -pl system -am test` *(fails: Non-resolvable parent POM: Network is unreachable for maven.aliyun.com)*

------
https://chatgpt.com/codex/tasks/task_e_68c7bf730340833081b1c1719d59112f