### PR TITLE
feat: add task attachment download

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcTaskManagerController.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/controller/TcTaskManagerController.java
@@ -35,6 +35,7 @@ import org.jeecgframework.poi.excel.view.JeecgEntityExcelView;
 
 import java.util.List;
 
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 /** 任务列表接口 */
 @RestController
@@ -162,5 +163,12 @@ public class TcTaskManagerController {
     @ApiOperation(value = "任务统计", notes = "获取总任务数、运行中、已完成和已取消任务数")
     public Result<TaskCountVO> statistics() {
         return Result.ok(taskManagerService.countTasks());
+    }
+
+    @GetMapping("/download")
+    @ApiOperationSupport(order = 13)
+    @ApiOperation(value = "下载节点附件", notes = "根据附件URL下载文件")
+    public void download(@RequestParam String url, HttpServletResponse response) {
+        taskManagerService.downloadAttachment(url, response);
     }
 }

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/TcTaskManagerService.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/TcTaskManagerService.java
@@ -13,6 +13,7 @@ import com.zjlab.dataservice.modules.tc.model.vo.OrbitPlanExportVO;
 import com.zjlab.dataservice.modules.tc.model.vo.TaskCountVO;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 
 /**
@@ -103,5 +104,13 @@ public interface TcTaskManagerService {
      * @return 任务数量统计
      */
     TaskCountVO countTasks();
+
+    /**
+     * 根据url下载节点附件
+     *
+     * @param url      附件在minio中的路径
+     * @param response 响应对象
+     */
+    void downloadAttachment(String url, HttpServletResponse response);
 
 }

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
@@ -59,6 +59,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import com.zjlab.dataservice.modules.storage.service.impl.MinioFileServiceImpl;
 import com.zjlab.dataservice.common.util.storage.MinioUtil;
+import com.zjlab.dataservice.modules.storage.model.dto.ObjectDownloadDto;
+
+import javax.servlet.http.HttpServletResponse;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1080,6 +1083,21 @@ public class TcTaskManagerServiceImpl implements TcTaskManagerService {
         vo.setCompleted(completed);
         vo.setCanceled(canceled);
         return vo;
+    }
+
+    @Override
+    public void downloadAttachment(String url, HttpServletResponse response) {
+        if (StringUtils.isBlank(url)) {
+            throw new BaseException(ResultCode.PARA_ERROR);
+        }
+        try {
+            ObjectDownloadDto dto = new ObjectDownloadDto();
+            dto.setBucketName(BUCKET_NAME);
+            dto.setPath(url);
+            minioFileService.download(dto, response);
+        } catch (Exception e) {
+            throw new BaseException(ResultCode.INTERNAL_SERVER_ERROR);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- add download endpoint for task attachments
- stream files from MinIO using existing storage service

## Testing
- `mvn -q -pl system/biz -am test` *(fails: Non-resolvable parent POM due to missing artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d235c6e08330b31a2b4f0c3cbc3e