### PR TITLE
Consolidate task operation flag

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/TcTaskNodeInstMapper.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/TcTaskNodeInstMapper.java
@@ -32,6 +32,8 @@ public interface TcTaskNodeInstMapper {
 
     List<CurrentNodeRow> selectCurrentNodes(@Param("taskIds") List<Long> taskIds);
 
+    List<Long> selectTaskIdsWithProcessedNodes(@Param("taskIds") List<Long> taskIds);
+
     Long countDoneNodeInst(@Param("taskId") Long taskId);
 
     int updateNodeInstCancel(@Param("taskId") Long taskId, @Param("userId") String userId);

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskNodeInstMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskNodeInstMapper.xml
@@ -59,6 +59,15 @@
         ORDER BY ni.task_id, ni.order_no, ni.id
     </select>
 
+    <select id="selectTaskIdsWithProcessedNodes" resultType="long">
+        SELECT DISTINCT task_id FROM tc_task_node_inst
+        WHERE del_flag = 0 AND status = 2
+          AND task_id IN
+            <foreach collection="taskIds" item="id" open="(" separator="," close=")">
+                #{id}
+            </foreach>
+    </select>
+
     <select id="countDoneNodeInst" resultType="long">
         SELECT COUNT(*) FROM tc_task_node_inst
         WHERE task_id = #{taskId} AND del_flag = 0 AND status = 2 FOR UPDATE

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/vo/TaskManagerListItemVO.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/vo/TaskManagerListItemVO.java
@@ -17,4 +17,5 @@ public class TaskManagerListItemVO extends TaskBaseVO {
     private List<SatelliteGroupVO> satellites;
     @JsonIgnore
     private String satellitesJson;
+    private boolean editable;
 }


### PR DESCRIPTION
## Summary
- collapse the task list editable/cancelable booleans into a single editable flag that governs both operations
- refresh the task manager documentation example and field description to explain the combined flag

## Testing
- `mvn -pl system/biz test` *(fails: unable to download parent POM because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ca65391fb883309143687d48896ccd