### PR TITLE
精简通知上下文字段并清理冗余解析

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/driver/DingTalkRobotDriver.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/driver/DingTalkRobotDriver.java
@@ -1,6 +1,8 @@
 package com.zjlab.dataservice.modules.notify.driver;
 
 import com.alibaba.fastjson.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 /**
@@ -9,6 +11,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class DingTalkRobotDriver implements NotifyDriver {
 
+    private static final Logger log = LoggerFactory.getLogger(DingTalkRobotDriver.class);
+
     @Override
     public byte channel() {
         return 1; // 钉钉
@@ -16,6 +20,8 @@ public class DingTalkRobotDriver implements NotifyDriver {
 
     @Override
     public SendResult send(String userId, String title, String content, JSONObject payload) {
+        log.info("DingTalkRobotDriver.send userId={}, title={}, content={}, payload={}",
+                userId, title, content, payload);
         // todo 这里简化为直接成功返回,后续需要接入具体send逻辑
         return SendResult.success();
     }

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/TcTaskManagerMapper.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/TcTaskManagerMapper.java
@@ -7,6 +7,7 @@ import com.zjlab.dataservice.modules.tc.model.vo.TaskManagerListItemVO;
 import com.zjlab.dataservice.modules.tc.model.dto.TaskManagerCreateDto;
 import com.zjlab.dataservice.modules.tc.model.vo.TaskDetailVO;
 import com.zjlab.dataservice.modules.tc.model.dto.TaskStatusCountDto;
+import com.zjlab.dataservice.modules.tc.model.dto.TaskNotifyContext;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
@@ -45,6 +46,9 @@ public interface TcTaskManagerMapper {
 
     /** 查询最近插入ID */
     Long selectLastInsertId();
+
+    /** 查询通知所需的任务上下文 */
+    TaskNotifyContext selectTaskNotifyContext(@Param("taskId") Long taskId);
 
     /** 根据角色ID集合查询用户ID */
     List<String> selectUserIdsByRoleIds(@Param("roleIds") List<String> roleIds);

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/TcTaskNodeInstMapper.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/TcTaskNodeInstMapper.java
@@ -2,6 +2,7 @@ package com.zjlab.dataservice.modules.tc.mapper;
 
 import com.zjlab.dataservice.modules.tc.model.dto.CurrentNodeRow;
 import com.zjlab.dataservice.modules.tc.model.vo.TaskNodeVO;
+import com.zjlab.dataservice.modules.tc.model.dto.NodeNotifyContext;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
@@ -83,5 +84,8 @@ public interface TcTaskNodeInstMapper {
 
     /** 查询节点预计最大时长 */
     Integer selectMaxDuration(@Param("nodeInstId") Long nodeInstId);
+
+    /** 查询通知所需的节点上下文 */
+    NodeNotifyContext selectNodeNotifyContext(@Param("nodeInstId") Long nodeInstId);
 }
 

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskManagerMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskManagerMapper.xml
@@ -181,6 +181,15 @@
         SELECT LAST_INSERT_ID()
     </select>
 
+    <select id="selectTaskNotifyContext" resultType="com.zjlab.dataservice.modules.tc.model.dto.TaskNotifyContext">
+        SELECT t.id AS taskId,
+               t.task_name AS taskName,
+               t.create_by AS creatorId,
+               t.create_time AS createTime
+        FROM tc_task t
+        WHERE t.id = #{taskId} AND t.del_flag = 0
+    </select>
+
     <select id="selectUserIdsByRoleIds" resultType="string">
         SELECT DISTINCT ur.user_id
         FROM sys_user_role ur

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskNodeInstMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/mapper/xml/TcTaskNodeInstMapper.xml
@@ -163,6 +163,17 @@
         WHERE id = #{nodeInstId} AND del_flag = 0
     </select>
 
+    <select id="selectNodeNotifyContext" resultType="com.zjlab.dataservice.modules.tc.model.dto.NodeNotifyContext">
+        SELECT t.task_name AS taskName,
+               ninfo.name AS nodeName,
+               ni.max_duration AS maxDuration,
+               ni.started_at AS startedAt
+        FROM tc_task_node_inst ni
+        JOIN tc_task t ON t.id = ni.task_id AND t.del_flag = 0
+        JOIN tc_node_info ninfo ON ninfo.id = ni.node_id
+        WHERE ni.id = #{nodeInstId} AND ni.del_flag = 0
+    </select>
+
     <select id="countOngoingNodeInst" resultType="long">
         SELECT COUNT(*) FROM tc_task_node_inst
         WHERE task_id = #{taskId} AND del_flag = 0 AND status IN (0,1)

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeNotifyContext.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/NodeNotifyContext.java
@@ -1,0 +1,20 @@
+package com.zjlab.dataservice.modules.tc.model.dto;
+
+import lombok.Data;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * 通知使用的节点上下文
+ */
+@Data
+public class NodeNotifyContext implements Serializable {
+
+    private static final long serialVersionUID = -5012584694309676380L;
+
+    private String taskName;
+    private String nodeName;
+    private Integer maxDuration;
+    private LocalDateTime startedAt;
+}

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/TaskNotifyContext.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/model/dto/TaskNotifyContext.java
@@ -1,0 +1,20 @@
+package com.zjlab.dataservice.modules.tc.model.dto;
+
+import lombok.Data;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * 通知使用的任务上下文
+ */
+@Data
+public class TaskNotifyContext implements Serializable {
+
+    private static final long serialVersionUID = -221895068756980509L;
+
+    private Long taskId;
+    private String taskName;
+    private String creatorId;
+    private LocalDateTime createTime;
+}


### PR DESCRIPTION
## Summary
- trim TaskNotifyContext and NodeNotifyContext to only keep template-required fields
- update task and node context mapper queries to fetch only the pared-down columns
- remove unused abnormal reason parsing when handling decision payloads

## Testing
- mvn -pl system/biz -am test *(fails: missing parent POM due to offline Maven repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68cb740a4168833095a6b57e5707852b