### PR TITLE
Fix node timeout notification rescheduling

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/dispatcher/NotifyDispatcher.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/dispatcher/NotifyDispatcher.java
@@ -95,12 +95,17 @@ public class NotifyDispatcher {
             return false;
         }
         Integer status = taskNodeInstMapper.selectNodeInstStatus(job.getBizId());
-        if (status == null || status != 1) {
+        if (status == null) {
             return false;
         }
-        LocalDateTime nextTime = LocalDateTime.now().plusMinutes(interval);
-        jobMapper.reschedule(job.getId(), nextTime);
-        return true;
+        // 节点状态：0-未激活、1-进行中、2-已完成、3-已取消、4-异常结束
+        // 仅当节点仍处于未激活或进行中时，才需要继续进行超时提醒。
+        if (status == 0 || status == 1) {
+            LocalDateTime nextTime = LocalDateTime.now().plusMinutes(interval);
+            jobMapper.reschedule(job.getId(), nextTime);
+            return true;
+        }
+        return false;
     }
 }
 


### PR DESCRIPTION
## Summary
- continue scheduling node timeout reminders while the node instance is still active
- avoid marking timeout jobs as successful until the node finishes

## Testing
- `mvn -pl system/biz -am test` *(fails: cannot reach https://maven.aliyun.com to resolve Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0f97023083309ad9ac0fd0c46702