### PR TITLE
Fix taskContext usage in submitAction

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
@@ -670,6 +670,7 @@ public class TcTaskManagerServiceImpl implements TcTaskManagerService {
         }
 
         String folder = TASK_FOLDER + "/taskId_" + dto.getTaskId() + "/nodeInstId_" + dto.getNodeInstId();
+        TaskNotifyContext taskContext = tcTaskManagerMapper.selectTaskNotifyContext(dto.getTaskId());
 
         // 4. 记录本次操作
         boolean hasSelectOrbitPlanAction = false;
@@ -797,7 +798,6 @@ public class TcTaskManagerServiceImpl implements TcTaskManagerService {
         TaskNodeActionVO decisionAction = dto.getActions().stream()
                 .filter(a -> a.getActionType() != null && a.getActionType() == NodeActionTypeEnum.DECISION.getCode())
                 .findFirst().orElse(null);
-        TaskNotifyContext taskContext = tcTaskManagerMapper.selectTaskNotifyContext(dto.getTaskId());
         if (decisionAction != null) {
             boolean processed = true;
             if (decisionAction.getActionPayload() != null) {


### PR DESCRIPTION
## Summary
- fetch the task notification context before using it in submitAction
- remove the duplicate declaration that caused compilation to fail

## Testing
- `mvn -pl system/biz -am -DskipTests compile` *(fails: Non-resolvable parent POM due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ad7882bc8330aa1de7aeae14b07f