### PR TITLE
feat: refresh orbit reminders when plan changes

### DIFF
--- a/doc/notify.md
+++ b/doc/notify.md
@@ -64,7 +64,7 @@ CREATE TABLE `tc_notify_job` (
 -- 索引
 CREATE INDEX `idx_job_status_time` ON `tc_notify_job`(`status`,`next_run_time`);
 CREATE INDEX `idx_job_biz` ON `tc_notify_job`(`biz_type`,`biz_id`);
-CREATE UNIQUE INDEX `uk_job_dedup` ON `tc_notify_job`(`dedup_key`);
+CREATE UNIQUE INDEX `uk_job_dedup` ON `tc_notify_job`(`dedup_key`, `del_flag`);
 CREATE INDEX `idx_job_channel` ON `tc_notify_job`(`channel`);
 ```
 

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/mapper/NotifyJobMapper.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/mapper/NotifyJobMapper.java
@@ -38,5 +38,8 @@ public interface NotifyJobMapper extends BaseMapper<NotifyJob> {
                           @Param("status") byte status,
                           @Param("operator") String operator,
                           @Param("expected") Collection<Byte> expectedStatuses);
+
+    int logicDeleteByIds(@Param("ids") Collection<Long> ids,
+                         @Param("operator") String operator);
 }
 

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/mapper/NotifyRecipientMapper.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/mapper/NotifyRecipientMapper.java
@@ -30,5 +30,8 @@ public interface NotifyRecipientMapper extends BaseMapper<NotifyRecipient> {
                              @Param("status") byte status,
                              @Param("operator") String operator,
                              @Param("expected") Collection<Byte> expectedStatuses);
+
+    int logicDeleteByJobIds(@Param("jobIds") Collection<Long> jobIds,
+                            @Param("operator") String operator);
 }
 

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/mapper/xml/NotifyJobMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/mapper/xml/NotifyJobMapper.xml
@@ -89,4 +89,16 @@
         </if>
     </update>
 
+    <update id="logicDeleteByIds">
+        UPDATE tc_notify_job
+        SET del_flag = 1,
+            update_by = #{operator},
+            update_time = NOW()
+        WHERE id IN
+        <foreach collection="ids" item="id" open="(" close=")" separator=",">
+            #{id}
+        </foreach>
+          AND del_flag = 0
+    </update>
+
 </mapper>

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/mapper/xml/NotifyRecipientMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/mapper/xml/NotifyRecipientMapper.xml
@@ -51,4 +51,16 @@
         </if>
     </update>
 
+    <update id="logicDeleteByJobIds">
+        UPDATE tc_notify_recipient
+        SET del_flag = 1,
+            update_by = #{operator},
+            update_time = NOW()
+        WHERE job_id IN
+        <foreach collection="jobIds" item="jid" open="(" close=")" separator=",">
+            #{jid}
+        </foreach>
+          AND del_flag = 0
+    </update>
+
 </mapper>

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/service/NotifyService.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/service/NotifyService.java
@@ -15,5 +15,7 @@ public interface NotifyService {
     void updateStatus(byte bizType, Collection<Long> bizIds,
                       byte status, Collection<Byte> expectedStatuses,
                       String operator);
+
+    void deleteByBiz(byte bizType, Collection<Long> bizIds, String operator);
 }
 

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/service/impl/NotifyServiceImpl.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/service/impl/NotifyServiceImpl.java
@@ -80,5 +80,19 @@ public class NotifyServiceImpl implements NotifyService {
         notifyJobMapper.updateStatusByIds(jobIds, status, operator, expectedStatuses);
         notifyRecipientMapper.updateStatusByJobIds(jobIds, status, operator, expectedStatuses);
     }
+
+    @Override
+    @Transactional
+    public void deleteByBiz(byte bizType, Collection<Long> bizIds, String operator) {
+        if (bizIds == null || bizIds.isEmpty()) {
+            return;
+        }
+        List<Long> jobIds = notifyJobMapper.selectIdsByBiz(bizType, bizIds, null);
+        if (jobIds == null || jobIds.isEmpty()) {
+            return;
+        }
+        notifyJobMapper.logicDeleteByIds(jobIds, operator);
+        notifyRecipientMapper.logicDeleteByJobIds(jobIds, operator);
+    }
 }
 

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
@@ -1481,9 +1481,7 @@ public class TcTaskManagerServiceImpl implements TcTaskManagerService {
             return;
         }
         List<Long> bizIds = Collections.singletonList(taskId);
-        List<Byte> expected = Collections.singletonList(NotifyJobStatusEnum.WAITING.getCode());
-        notifyService.updateStatus((byte) BizTypeEnum.ORBIT_REMIND.getCode(),
-                bizIds, NotifyJobStatusEnum.CANCELED.getCode(), expected, operator);
+        notifyService.deleteByBiz((byte) BizTypeEnum.ORBIT_REMIND.getCode(), bizIds, operator);
     }
 
     private void scheduleOrbitReminders(Long taskId, String taskName, List<OrbitPlanExportVO> orbitPlans,


### PR DESCRIPTION
## Summary
- extend the notify job DDL description to make the dedup key unique together with del_flag
- add mapper and service helpers to logically delete notify jobs/recipients for specific biz keys
- clear existing orbit reminders via logical delete before scheduling refreshed ones on node submission

## Testing
- mvn -pl system/biz -am -DskipTests package *(fails: repository unavailable in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d8d2cb2083308a1ced735437ce41