### PR TITLE
Limit notify retries to four before failing

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/dispatcher/NotifyDispatcher.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/dispatcher/NotifyDispatcher.java
@@ -28,6 +28,8 @@ import java.util.Map;
 @Component
 public class NotifyDispatcher {
 
+    private static final int MAX_RETRY_COUNT = 4;
+
     @Autowired
     private NotifyJobMapper jobMapper;
     @Autowired
@@ -69,7 +71,11 @@ public class NotifyDispatcher {
                 }
             } else {
                 int nextRetry = j.getRetryCount() + 1;
-                jobMapper.scheduleRetry(j.getId(), calcNext(nextRetry), nextRetry);
+                if (nextRetry > MAX_RETRY_COUNT) {
+                    jobMapper.markFailure(j.getId());
+                } else {
+                    jobMapper.scheduleRetry(j.getId(), calcNext(nextRetry), nextRetry);
+                }
             }
         }
     }

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/mapper/NotifyJobMapper.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/mapper/NotifyJobMapper.java
@@ -22,6 +22,8 @@ public interface NotifyJobMapper extends BaseMapper<NotifyJob> {
 
     int markSuccess(@Param("id") long id);
 
+    int markFailure(@Param("id") long id);
+
     int scheduleRetry(@Param("id") long id,
                       @Param("nextRunTime") LocalDateTime nextRunTime,
                       @Param("retryCount") int retryCount);

--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/mapper/xml/NotifyJobMapper.xml
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/notify/mapper/xml/NotifyJobMapper.xml
@@ -29,6 +29,13 @@
         WHERE id = #{id}
     </update>
 
+    <update id="markFailure">
+        UPDATE tc_notify_job
+        SET status = 2,
+            update_time = NOW()
+        WHERE id = #{id}
+    </update>
+
     <update id="scheduleRetry">
         UPDATE tc_notify_job
         SET next_run_time = #{nextRunTime},


### PR DESCRIPTION
## Summary
- stop rescheduling notify jobs after the fourth retry attempt
- add mapper support for marking notify jobs as failed
- extract the notify retry cap into a dedicated constant in `NotifyDispatcher`

## Testing
- `mvn -pl system/biz -am test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d35507b9088330a41a89e265103cd9