### PR TITLE
Only schedule orbit reminders for used orbit plans

### DIFF
--- a/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
+++ b/system/biz/src/main/java/com/zjlab/dataservice/modules/tc/service/impl/TcTaskManagerServiceImpl.java
@@ -1514,6 +1514,9 @@ public class TcTaskManagerServiceImpl implements TcTaskManagerService {
             if (plan == null) {
                 continue;
             }
+            if (!Boolean.TRUE.equals(plan.getUsed())) {
+                continue;
+            }
             LocalDateTime inTime = parseOrbitPlanTime(plan.getInTime());
             if (inTime == null) {
                 continue;


### PR DESCRIPTION
## Summary
- skip scheduling orbit reminders for orbit plans that are not marked as used

## Testing
- `mvn -pl system/biz -am test` *(fails: unable to resolve dependencies from maven.aliyun.com due to unknown host)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a1f9f330833081467555b01ed7c3